### PR TITLE
Add missing properties to Product class.

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -214,6 +214,10 @@ class ProductCore extends ObjectModel
     public $pack_stock_type = 3;
     // @codingStandardsIgnoreEnd
 
+    public $packItems;
+
+    public $productDownload;
+
     public static $definition = [
         'table'          => 'product',
         'primary'        => 'id_product',


### PR DESCRIPTION
It would cause errors without these two properties in place when loading the product edit page from backend office.

Note that the error doesn't happen with sample data, while I can reproduce it after I copy over the products and categories tables from an existing PS1.6 DB to TB1.0.0 DB