### PR TITLE
Glitch in classes/UrlRewrite.php

### DIFF
--- a/classes/UrlRewrite.php
+++ b/classes/UrlRewrite.php
@@ -506,7 +506,7 @@ class UrlRewriteCore extends Objectmodel
                     $categoryRewrite = '';
                     $idCategory = (int) $productInfo['id_category_default'];
                     $depth = 0;
-                    while ($idCategory && $depth < self::MAX_CATEGORY_DEPTH && $categories[$idCategory]['rewrite']) {
+                    while ($idCategory && $idCategory < sizeof($categories) && $depth < self::MAX_CATEGORY_DEPTH && $categories[$idCategory]['rewrite']) {
                         $categoryRewrite = '/'.$categories[$idCategory]['rewrite'].$categoryRewrite;
                         $idCategory = (int) $categories[$idCategory]['id_parent'];
                         $depth++;


### PR DESCRIPTION
Environment: default installation, then enabled multishop, created
             two shops, switched back to monoshop.

Behaviour: some 15 messages similar like this one when accessing
           backoffice -> Preferences -> SEO & URLs:

    Notice: Undefined offset: 10 in /var/www/html/ThirtyBees/classes/UrlRewrite.php on line 509
    Notice: Undefined offset: 10 in /var/www/html/ThirtyBees/classes/UrlRewrite.php on line 509
    Notice: Undefined offset: 11 in /var/www/html/ThirtyBees/classes/UrlRewrite.php on line 509
    Notice: Undefined offset: 11 in /var/www/html/ThirtyBees/classes/UrlRewrite.php on line 509

Diagnosis: $idCategory is larger than array size of $categories.

Cure: well, the obvious quick fix is to check the array pointer, which is what I did. However, these messages might hint to something actually going wrong, so just removing the message covers the actual problem without solving it.