### PR TITLE
File based ShopUrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ admin-dev/themes/*/cache/*
 
 config/settings.inc.php
 config/settings.old.php
+config/shop.inc.php
 config/xml/*
 !config/xml/themes/default.xml
 

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -431,6 +431,14 @@ class ConfigurationCore extends ObjectModel
                 static::$_cache[static::$definition['table']][$lang]['global'][$row['name']] = $row['value'];
             }
         }
+
+        // Adjust automatic values.
+        if (static::get('PS_SHOP_DOMAIN') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN', $_SERVER['HTTP_HOST']);
+        }
+        if (static::get('PS_SHOP_DOMAIN_SSL') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN_SSL', $_SERVER['HTTP_HOST']);
+        }
     }
 
     /**
@@ -669,6 +677,14 @@ class ConfigurationCore extends ObjectModel
                     );
                 }
             }
+        }
+
+        // Adjust automatic values.
+        if ($key === 'PS_SHOP_DOMAIN' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
+        }
+        if ($key === 'PS_SHOP_DOMAIN_SSL' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
         }
 
         Configuration::set($key, $values, $idShopGroup, $idShop);

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -117,6 +117,30 @@ abstract class ObjectFileModelCore extends ObjectModel
     }
 
     /**
+     * Gets one or all record(s).
+     *
+     * @param bool $id Record to get. All records if NULL.
+     *
+     * @return array Array with record or array with all record arrays.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function get($id = NULL)
+    {
+        global $shopUrlConfig;
+
+        if (!is_array($shopUrlConfig)) {
+            // foreach() loops don't like NULL.
+            return [];
+        } else if ($id) {
+            return $shopUrlConfig[$id];
+        } else {
+            return $shopUrlConfig;
+        }
+    }
+
+    /**
      * Writes the whole objects array as-is to it's file. Should be executed
      * after any permanent change to that array.
      *

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -219,6 +219,67 @@ abstract class ObjectFileModelCore extends ObjectModel
         return $result;
     }
 
+     /**
+      * Updates the current object in the file based storage.
+      *
+      * @param bool $nullValues Ignored, for compatibility with ObjectModel.
+      *
+      * @return bool
+      * @throws PrestaShopException
+      */
+    public function update($nullValues = false)
+    {
+        global $shopUrlConfig;
+
+        $result = true;
+
+        // @hook actionObject*UpdateBefore
+        Hook::exec('actionObjectUpdateBefore', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'UpdateBefore', ['object' => $this]);
+
+        // Automatically fill dates
+        if (property_exists($this, 'date_upd')) {
+            $this->date_upd = date('Y-m-d H:i:s');
+            if (isset($this->update_fields) && is_array($this->update_fields) && count($this->update_fields)) {
+                $this->update_fields['date_upd'] = true;
+            }
+        }
+
+        // Automatically fill dates
+        if (property_exists($this, 'date_add') && $this->date_add == null) {
+            $this->date_add = date('Y-m-d H:i:s');
+            if (isset($this->update_fields) && is_array($this->update_fields) && count($this->update_fields)) {
+                $this->update_fields['date_add'] = true;
+            }
+        }
+
+        $idShopList = Shop::getContextListShopID();
+        if (count($this->id_shop_list) > 0) {
+            $idShopList = $this->id_shop_list;
+        }
+
+        if (Shop::checkIdShopDefault($this->def['table']) && !$this->id_shop_default) {
+            $this->id_shop_default = (in_array(Configuration::get('PS_SHOP_DEFAULT'), $idShopList) == true) ? Configuration::get('PS_SHOP_DEFAULT') : min($idShopList);
+        }
+
+        // Array update.
+        $fields = $this->getFields();
+        unset($fields[$this->def['primary']]); // Set by getFields(), but not needed.
+        $shopUrlConfig[$this->id] = $fields;
+        $result = static::write();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
+
+        /* Associations, multilingual fields not yet implemented. */
+
+        // @hook actionObject*UpdateAfter
+        Hook::exec('actionObjectUpdateAfter', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'UpdateAfter', ['object' => $this]);
+
+        return $result;
+    }
+
     /**
      * Deletes current object from the file based storage.
      *

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -146,4 +146,76 @@ abstract class ObjectFileModelCore extends ObjectModel
 
         return $result;
     }
+
+    /**
+     * Adds current object to the file based storage.
+     *
+     * @param bool $autoDate
+     * @param bool $nullValues Ignored, for compatibility with ObjectModel.
+     *
+     * @return bool Insertion result
+     * @throws PrestaShopException
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function add($autoDate = true, $nullValues = false)
+    {
+        global $shopUrlConfig;
+
+        $result = true;
+
+        if (isset($this->id) && !$this->force_id) {
+            unset($this->id);
+        }
+
+        // @hook actionObject*AddBefore
+        Hook::exec('actionObjectAddBefore', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'AddBefore', ['object' => $this]);
+
+        // Automatically fill dates
+        if ($autoDate && property_exists($this, 'date_add')) {
+            $this->date_add = date('Y-m-d H:i:s');
+        }
+        if ($autoDate && property_exists($this, 'date_upd')) {
+            $this->date_upd = date('Y-m-d H:i:s');
+        }
+
+        if (Shop::isTableAssociated($this->def['table'])) {
+            $idShopList = Shop::getContextListShopID();
+            if (count($this->id_shop_list) > 0) {
+                $idShopList = $this->id_shop_list;
+            }
+        }
+
+        if (Shop::checkIdShopDefault($this->def['table'])) {
+            $this->id_shop_default = (in_array(Configuration::get('PS_SHOP_DEFAULT'), $idShopList) == true) ? Configuration::get('PS_SHOP_DEFAULT') : min($idShopList);
+        }
+        $fields = $this->getFields();
+
+        // Find the smallest insertion point. count($array) is unreliable,
+        // because there can be gaps after previous deletions.
+        $newId = 1;
+        while (is_array($shopUrlConfig) &&
+               array_key_exists($newId, $shopUrlConfig)) {
+            $newId++;
+        }
+
+        // Array insertion.
+        $shopUrlConfig[$newId] = $fields;
+        $result = $this->write();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
+
+        $this->id = $newId;
+
+        /* Associations, multilingual fields not yet implemented. */
+
+        // @hook actionObject*AddAfter
+        Hook::exec('actionObjectAddAfter', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'AddAfter', ['object' => $this]);
+
+        return $result;
+    }
 }

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -218,4 +218,38 @@ abstract class ObjectFileModelCore extends ObjectModel
 
         return $result;
     }
+
+    /**
+     * Deletes current object from the file based storage.
+     *
+     * @return bool True if delete was successful
+     * @throws PrestaShopException
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function delete()
+    {
+        global $shopUrlConfig;
+
+        // @hook actionObject*DeleteBefore
+        Hook::exec('actionObjectDeleteBefore', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'DeleteBefore', ['object' => $this]);
+
+        /* Associations, multilingual fields not yet implemented. */
+
+        if (is_array($shopUrlConfig)) {
+            unset($shopUrlConfig[$this->id]);
+        }
+        $result = $this->write();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
+
+        // @hook actionObject*DeleteAfter
+        Hook::exec('actionObjectDeleteAfter', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'DeleteAfter', ['object' => $this]);
+
+        return $result;
+    }
 }

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * 2017 Thirty Bees
+ *
+ * Thirty Bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017 Thirty Bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ *  @author    Thirty Bees <contact@thirtybees.com>
+ *  @copyright 2017 Thirty Bees
+ *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * This class is a shim between class ObjectModel and a class using ObjectModel.
+ * It's purpose is to not access database storage, but a regular file instead.
+ * Accordingly, all methods accessing the DB are overridden; everything else
+ * is left for the parent.
+ *
+ * Storing data in a file is useful for e.g. configuration data (read often,
+ * changed rarely). It also allows to change data by a shell script, which is
+ * crucial for shop synchronisation.
+ */
+
+// This file might not exist. For example, at install time it doesn't.
+// Accordingly, we also have to check for the existence of $shopUrlConfig
+// on every read access.
+@include_once(_PS_ROOT_DIR_.'/config/shop.inc.php');
+
+/**
+ * Class ObjectFileModelCore
+ *
+ * This class is a shim between ObjectModel and inherited classes like
+ * ShopUrlCore, which redirects storage to a file instead of the database.
+ *
+ * @TODO: file content is in variable $shopUrlConfig, which is hardcoded
+ *        here. This needs abstraction as soon as another usage of this class
+ *        comes up.
+ *
+ * @since 1.1.0
+ */
+abstract class ObjectFileModelCore extends ObjectModel
+{
+    /**
+     * Builds the object
+     *
+     * @param int|null $id     If specified, loads and existing object from DB (optional).
+     * @param int|null $idLang Required if object is multilingual (optional).
+     * @param int|null $idShop ID shop for objects with multishop tables.
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function __construct($id = null, $idLang = null, $idShop = null)
+    {
+        global $shopUrlConfig;
+
+        $className = get_class($this);
+        if (!isset(ObjectFileModel::$loaded_classes[$className])) {
+            $this->def = ObjectFileModel::getDefinition($className);
+            ObjectFileModel::$loaded_classes[$className] = get_object_vars($this);
+        } else {
+            foreach (ObjectFileModel::$loaded_classes[$className] as $key => $value) {
+                $this->{$key} = $value;
+            }
+        }
+
+        if ( ! is_writable(_PS_ROOT_DIR_.$this->def['path']) &&
+             ! is_writable(dirname(_PS_ROOT_DIR_.$this->def['path']))) {
+            throw new PrestaShopException('Storage file '._PS_ROOT_DIR_.$this->def['path'].' for class '.get_class($this).' not writable.');
+        }
+
+        if ($idLang !== null) {
+            $this->id_lang = (Language::getLanguage($idLang) !== false) ? $idLang : Configuration::get('PS_LANG_DEFAULT');
+        }
+
+        if ($idShop && $this->isMultishop()) {
+            $this->id_shop = (int) $idShop;
+            $this->get_shop_from_context = false;
+        }
+
+        if ($this->isMultishop() && !$this->id_shop) {
+            $this->id_shop = Context::getContext()->shop->id;
+        }
+
+        if ($id) {
+            if (is_array($shopUrlConfig)) {
+                // This is what Adapter_EntityMapper does after database access.
+                foreach ($shopUrlConfig[$id] as $key => $value) {
+                    if (property_exists($this, $key)) {
+                        $this->{$key} = $value;
+                    } else {
+                        unset($shopUrlConfig[$id][$key]);
+                    }
+                }
+            }
+            $this->id = $id;
+        }
+    }
+
+    /**
+     * Writes the whole objects array as-is to it's file. Should be executed
+     * after any permanent change to that array.
+     *
+     * @return bool Number of bytes written or false equivalent on failure.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function write()
+    {
+        global $shopUrlConfig;
+
+        $result = file_put_contents(_PS_ROOT_DIR_.$this->def['path'],
+            "<?php\n\n".
+            'global $shopUrlConfig;'."\n\n".
+            '$shopUrlConfig = '.var_export($shopUrlConfig, true).';'."\n");
+
+        // Clear most citizens in cache-mess-city. Else the include_once()
+        // above may well read an old version on the next page load.
+        Tools::clearSmartyCache();
+        Tools::clearXMLCache();
+        Cache::getInstance()->flush();
+        PageCache::flush();
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
+
+        return $result;
+    }
+}

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -228,9 +228,6 @@ abstract class ObjectFileModelCore extends ObjectModel
         // Array insertion.
         $shopUrlConfig[$newId] = $fields;
         $result = $this->write();
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push();
 
         $this->id = $newId;
 
@@ -291,9 +288,6 @@ abstract class ObjectFileModelCore extends ObjectModel
         unset($fields[$this->def['primary']]); // Set by getFields(), but not needed.
         $shopUrlConfig[$this->id] = $fields;
         $result = static::write();
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push();
 
         /* Associations, multilingual fields not yet implemented. */
 
@@ -327,9 +321,6 @@ abstract class ObjectFileModelCore extends ObjectModel
             unset($shopUrlConfig[$this->id]);
         }
         $result = $this->write();
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push();
 
         // @hook actionObject*DeleteAfter
         Hook::exec('actionObjectDeleteAfter', ['object' => $this]);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3041,30 +3041,30 @@ class ToolsCore
         }
 
         $domains = [];
-        foreach (ShopUrl::getShopUrls() as $shop_url) {
-            /** @var ShopUrl $shop_url */
-            if (!isset($domains[$shop_url->domain])) {
-                $domains[$shop_url->domain] = [];
+        foreach (ShopUrl::get() as $shopUrl) {
+            /** @var ShopUrl $shopUrl */
+            if (!isset($domains[$shopUrl['domain']])) {
+                $domains[$shopUrl['domain']] = [];
             }
 
-            $domains[$shop_url->domain][] = [
-                'physical' => $shop_url->physical_uri,
-                'virtual'  => $shop_url->virtual_uri,
-                'id_shop'  => $shop_url->id_shop,
+            $domains[$shopUrl['domain']][] = [
+                'physical' => $shopUrl['physical_uri'],
+                'virtual'  => $shopUrl['virtual_uri'],
+                'id_shop'  => $shopUrl['id_shop'],
             ];
 
-            if ($shop_url->domain == $shop_url->domain_ssl) {
+            if ($shopUrl['domain'] == $shopUrl['domain_ssl']) {
                 continue;
             }
 
-            if (!isset($domains[$shop_url->domain_ssl])) {
-                $domains[$shop_url->domain_ssl] = [];
+            if (!isset($domains[$shopUrl['domain_ssl']])) {
+                $domains[$shopUrl['domain_ssl']] = [];
             }
 
-            $domains[$shop_url->domain_ssl][] = [
-                'physical' => $shop_url->physical_uri,
-                'virtual'  => $shop_url->virtual_uri,
-                'id_shop'  => $shop_url->id_shop,
+            $domains[$shopUrl['domain_ssl']][] = [
+                'physical' => $shopUrl['physical_uri'],
+                'virtual'  => $shopUrl['virtual_uri'],
+                'id_shop'  => $shopUrl['id_shop'],
             ];
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4659,4 +4659,50 @@ class AdminControllerCore extends Controller
 
         return $result;
     }
+
+    /**
+     * Compare by values of a key inside a pair of arrays. Try hard to sort
+     * numbers as numbers and strings as strings.
+     *
+     * Can be used for usort(). The key is given in $this->_orderBy. Sort
+     * direction is in $this->_orderWay as 'ASC' or 'DESC', uppercase.
+     *
+     * @param array $a
+     * @param array $b
+     *
+     * @return -1, 0, 1
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    protected function compareByArrayValues($a, $b)
+    {
+        $a = $a[$this->_orderBy];
+        $b = $b[$this->_orderBy];
+
+        // Depending on the origin of the arrays, numbers can be either actual
+        // numbers or strings with digits inside. Sometimes even mixed. Let's
+        // try our best to compare them properly, e.g. 2 > '1'.
+
+        if ((is_string($a) && (int)$a === 0) ||
+            (is_string($b) && (int)$b === 0)) {
+            // String comparison.
+            if ($this->_orderWay === 'ASC') {
+                return strcmp($b, $a);
+            } else {
+                return strcmp($a, $b);
+            }
+        }
+
+        // Number comparison.
+        if ($a == $b) {  // Intentionally not '===' here.
+            return 0;
+        }
+        if ($this->_orderWay === 'ASC') {
+            return ($a < $b) ? 1 : -1;
+        } else {
+            return ($a > $b) ? 1 : -1;
+        }
+    }
+
 }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -347,7 +347,7 @@ class ShopCore extends ObjectModel
         $res &= Db::getInstance()->delete('stock_available', '`id_shop` = '.(int) $this->id);
 
         // Remove urls
-        $res &= Db::getInstance()->delete('shop_url', '`id_shop` = '.(int) $this->id);
+        ShopUrl::deleteShopUrls($this->id);
 
         // Remove currency restrictions
         $res &= Db::getInstance()->delete('module_currency', '`id_shop` = '.(int) $this->id);

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -684,12 +684,18 @@ class ShopCore extends ObjectModel
      */
     public function getUrls()
     {
-        $sql = 'SELECT *
-				FROM '._DB_PREFIX_.'shop_url
-				WHERE active = 1
-					AND id_shop = '.(int) $this->id;
+        $result = ShopUrl::get();
+        foreach ($result as $id => &$url) {
+            // Remove the ones we don't need.
+            if ($url['id_shop'] != $this->id || !$url['active']) {
+                unset($result[$id]);
+            } else {
+                $url['id_shop_url'] = $id;
+            }
+        }
+        unset($url);
 
-        return Db::getInstance()->executeS($sql);
+        return $result;
     }
 
     /**

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -250,8 +250,16 @@ class ShopCore extends ObjectModel
         $this->theme_directory = $row['directory'];
         $this->physical_uri = $row['physical_uri'];
         $this->virtual_uri = $row['virtual_uri'];
-        $this->domain = $row['domain'];
-        $this->domain_ssl = $row['domain_ssl'];
+        if ($row['domain'] === '*automatic*') {
+            $this->domain = $_SERVER['HTTP_HOST'];
+        } else {
+            $this->domain = $row['domain'];
+        }
+        if ($row['domain_ssl'] === '*automatic*') {
+            $this->domain_ssl = $_SERVER['HTTP_HOST'];
+        } else {
+            $this->domain_ssl = $row['domain'];
+        }
 
         return true;
     }
@@ -475,6 +483,31 @@ class ShopCore extends ObjectModel
                 }
             }
         } else {
+            // Handle automatic shop URLs.
+            if (!$idShop) {
+                // The whole purpose of this block is to find out wether
+                // we should load the default shop with or without redirection.
+                // Keeping $idShop at false means with redirection.
+                $idDefaultShop = Configuration::get('PS_SHOP_DEFAULT');
+
+                // Get this directly from the database to see '*automatic*'.
+                $sql = 'SELECT domain, domain_ssl
+                        FROM '._DB_PREFIX_.'shop_url
+                        WHERE id_shop = \''.pSQL($idDefaultShop).'\'';
+
+                $result = Db::getInstance()->executeS($sql);
+
+                if (Configuration::get('PS_SSL_ENABLED')) {
+                    if ($result[0]['domain_ssl'] === '*automatic*') {
+                        $idShop = $idDefaultShop;
+                    }
+                } else {
+                    if ($result[0]['domain'] === '*automatic*') {
+                        $idShop = $idDefaultShop;
+                    }
+                }
+            }
+
             $shop = new Shop($idShop);
             if (!Validate::isLoadedObject($shop) || !$shop->active) {
                 // No shop found ... too bad, let's redirect to default shop
@@ -525,7 +558,7 @@ class ShopCore extends ObjectModel
 
     /**
      * @return Address the current shop address
-     *                 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -551,7 +584,7 @@ class ShopCore extends ObjectModel
      * Get shop theme name
      *
      * @return string
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -564,7 +597,7 @@ class ShopCore extends ObjectModel
      * Get shop URI
      *
      * @return string
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -580,7 +613,7 @@ class ShopCore extends ObjectModel
      * @param string $addBaseUri     if set to true, shop base uri will be added
      *
      * @return string complete base url of current shop
-     *                
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -605,7 +638,7 @@ class ShopCore extends ObjectModel
      * Get group of current shop
      *
      * @return ShopGroup
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -622,7 +655,7 @@ class ShopCore extends ObjectModel
      * Get root category of current shop
      *
      * @return int
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -635,7 +668,7 @@ class ShopCore extends ObjectModel
      * Get list of shop's urls
      *
      * @return array
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -653,7 +686,7 @@ class ShopCore extends ObjectModel
      * Check if current shop ID is the same as default shop in configuration
      *
      * @return bool
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -666,7 +699,7 @@ class ShopCore extends ObjectModel
      * Get the associated table if available
      *
      * @return array
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -683,7 +716,7 @@ class ShopCore extends ObjectModel
      * check if the table has an id_shop_default
      *
      * @return bool
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -700,7 +733,7 @@ class ShopCore extends ObjectModel
      * Get list of associated tables to shop
      *
      * @return array
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -720,7 +753,7 @@ class ShopCore extends ObjectModel
      * @param array  $table_details
      *
      * @return bool
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -741,7 +774,7 @@ class ShopCore extends ObjectModel
      * @param string $table
      *
      * @return bool
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -758,7 +791,7 @@ class ShopCore extends ObjectModel
      * Load list of groups and shops, and cache it
      *
      * @param bool $refresh
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -823,7 +856,7 @@ class ShopCore extends ObjectModel
 
     /**
      * @return array|null
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
@@ -853,7 +886,7 @@ class ShopCore extends ObjectModel
      * @param bool $getAsListId
      *
      * @return array
-     * 
+     *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -503,20 +503,17 @@ class ShopCore extends ObjectModel
                 // Keeping $idShop at false means with redirection.
                 $idDefaultShop = Configuration::get('PS_SHOP_DEFAULT');
 
-                // Get this directly from the database to see '*automatic*'.
-                $sql = 'SELECT domain, domain_ssl
-                        FROM '._DB_PREFIX_.'shop_url
-                        WHERE id_shop = \''.pSQL($idDefaultShop).'\'';
-
-                $result = Db::getInstance()->executeS($sql);
-
-                if (Configuration::get('PS_SSL_ENABLED')) {
-                    if ($result[0]['domain_ssl'] === '*automatic*') {
-                        $idShop = $idDefaultShop;
-                    }
-                } else {
-                    if ($result[0]['domain'] === '*automatic*') {
-                        $idShop = $idDefaultShop;
+                foreach (ShopUrl::get() as $url) {
+                    if ($url['id_shop'] == $idDefaultShop && $url['main']) {
+                        if (Configuration::get('PS_SSL_ENABLED')) {
+                            if ($url['domain_ssl'] === '*automatic*') {
+                                $idShop = $idDefaultShop;
+                            }
+                        } else {
+                            if ($url['domain'] === '*automatic*') {
+                                $idShop = $idDefaultShop;
+                            }
+                        }
                     }
                 }
             }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -830,12 +830,10 @@ class ShopCore extends ObjectModel
             $where .= 'AND es.id_employee = '.(int) $employee->id;
         }
 
-        $sql = 'SELECT gs.*, s.*, gs.name AS group_name, s.name AS shop_name, s.active, su.domain, su.domain_ssl, su.physical_uri, su.virtual_uri
+        $sql = 'SELECT gs.*, s.*, gs.name AS group_name, s.name AS shop_name, s.active
 				FROM '._DB_PREFIX_.'shop_group gs
 				LEFT JOIN '._DB_PREFIX_.'shop s
 					ON s.id_shop_group = gs.id_shop_group
-				LEFT JOIN '._DB_PREFIX_.'shop_url su
-					ON s.id_shop = su.id_shop AND su.main = 1
 				'.$from.'
 				WHERE s.deleted = 0
 					AND gs.deleted = 0
@@ -855,17 +853,30 @@ class ShopCore extends ObjectModel
                     ];
                 }
 
-                static::$shops[$row['id_shop_group']]['shops'][$row['id_shop']] = [
+                // Find matching main URL.
+                foreach (ShopUrl::get() as $url) {
+                    if ($url['id_shop'] == $row['id_shop'] && $url['main']) {
+                        break;
+                    }
+                    unset($url);
+                }
+
+                $dest = &static::$shops[$row['id_shop_group']]['shops'][$row['id_shop']];
+                $dest = [
                     'id_shop'       => $row['id_shop'],
                     'id_shop_group' => $row['id_shop_group'],
                     'name'          => $row['shop_name'],
                     'id_theme'      => $row['id_theme'],
                     'id_category'   => $row['id_category'],
-                    'domain'        => $row['domain'],
-                    'domain_ssl'    => $row['domain_ssl'],
-                    'uri'           => $row['physical_uri'].$row['virtual_uri'],
                     'active'        => $row['active'],
                 ];
+                if (isset($url)) {
+                    $dest += [
+                        'domain'     => $url['domain'],
+                        'domain_ssl' => $url['domain_ssl'],
+                        'uri'        => $url['physical_uri'].$url['virtual_uri'],
+                    ];
+                }
             }
         }
     }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -930,15 +930,11 @@ class ShopCore extends ObjectModel
             return false;
         }
 
-        $query = new DbQuery();
-        $query->select('domain');
-        $query->from('shop_url');
-        $query->where('main = 1');
-        $query->where('active = 1');
-        $query .= $this->addSqlRestriction(Shop::SHARE_ORDER);
         $domains = [];
-        foreach (Db::getInstance()->executeS($query) as $row) {
-            $domains[] = $row['domain'];
+        foreach (ShopUrl::get() as $url) {
+            if ($url['main'] && $url['active']) {
+                $domains[] = $url['domain'];
+            }
         }
 
         return $domains;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -415,47 +415,52 @@ class ShopCore extends ObjectModel
     {
         // Find current shop from URL
         if (!($idShop = Tools::getValue('id_shop')) || defined('_PS_ADMIN_DIR_')) {
-            $foundUri = '';
-            $isMainUri = false;
             $host = Tools::getHttpHost();
             $requestUri = rawurldecode($_SERVER['REQUEST_URI']);
 
-            $sql = 'SELECT s.id_shop, CONCAT(su.physical_uri, su.virtual_uri) AS uri, su.domain, su.main
-					FROM '._DB_PREFIX_.'shop_url su
-					LEFT JOIN '._DB_PREFIX_.'shop s ON (s.id_shop = su.id_shop)
-					WHERE (su.domain = \''.pSQL($host).'\' OR su.domain_ssl = \''.pSQL($host).'\')
-						AND s.active = 1
-						AND s.deleted = 0
-					ORDER BY LENGTH(CONCAT(su.physical_uri, su.virtual_uri)) DESC';
-
+            $allUrls = ShopUrl::get();
+            $sql = 'SELECT id_shop, active, deleted
+                    FROM '._DB_PREFIX_.'shop';
             $result = Db::getInstance()->executeS($sql);
 
-            $through = false;
-            foreach ($result as $row) {
-                // An URL matching current shop was found
-                if (preg_match('#^'.preg_quote($row['uri'], '#').'#i', $requestUri)) {
-                    $through = true;
-                    $idShop = $row['id_shop'];
-                    $foundUri = $row['uri'];
-                    if ($row['main']) {
-                        $isMainUri = true;
+            // Search for a shop matching this host.
+            $idShop = false;
+            $isMainUri = false;
+            $foundUri = false;
+            foreach ($allUrls as $url) {
+                if ($host === $url['domain'] || $host === $url['domain_ssl']) {
+                    $uri = $url['physical_uri'].$url['virtual_uri'];
+                    foreach ($result as $row) {
+                        if ($row['id_shop'] == $url['id_shop'] &&
+                            $row['active'] && !$row['deleted'] &&
+                            preg_match('#^'.preg_quote($uri, '#').'#i', $requestUri)) {
+
+                            $idShop = $row['id_shop'];
+                            $foundUri = $uri;
+                            if ($url['main']) {
+                                $isMainUri = true;
+                            }
+                            break;
+                        }
                     }
-                    break;
+                    if ($idShop) {
+                        break;
+                    }
                 }
             }
 
             // If an URL was found but is not the main URL, redirect to main URL
-            if ($through && $idShop && !$isMainUri) {
-                foreach ($result as $row) {
-                    if ($row['id_shop'] == $idShop && $row['main']) {
+            if ($idShop && !$isMainUri) {
+                foreach ($allUrls as $url) {
+                    if ($url['id_shop'] == $idShop && $url['main']) {
                         $requestUri = substr($requestUri, strlen($foundUri));
-                        $url = str_replace('//', '/', $row['domain'].$row['uri'].$requestUri);
+                        $uri = str_replace('//', '/', $url['domain'].$foundUri.$requestUri);
                         $redirectType = Configuration::get('PS_CANONICAL_REDIRECT');
                         $redirectCode = ($redirectType == 1 ? '302' : '301');
                         $redirectHeader = ($redirectType == 1 ? 'Found' : 'Moved Permanently');
                         header('HTTP/1.0 '.$redirectCode.' '.$redirectHeader);
                         header('Cache-Control: no-cache');
-                        header('Location: http://'.$url);
+                        header('Location: http://'.$uri);
                         exit;
                     }
                 }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -29,14 +29,12 @@
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 
-include_once(_PS_ROOT_DIR_.'/config/shop.inc.php');
-
 /**
  * Class ShopUrlCore
  *
  * @since 1.0.0
  */
-class ShopUrlCore extends ObjectModel
+class ShopUrlCore extends ObjectFileModel
 {
     // @codingStandardsIgnoreStart
     public $id_shop;
@@ -103,7 +101,7 @@ class ShopUrlCore extends ObjectModel
             unset($shopUrlConfig[$url['id_shop_url']]['id_shop_url']);
         }
 
-        (new ShopUrl)->saveShopUrlConfig();
+        $this->write();
 
         return $result;
     }
@@ -125,22 +123,6 @@ class ShopUrlCore extends ObjectModel
 
             Db::getInstance()->insert('shop_url', $url);
         }
-    }
-
-    /**
-     * @return int|bool Number of bytes written or false-equivalent on failure.
-     *
-     * @since   1.1.0
-     * @version 1.1.0 Initial version
-     */
-    public function saveShopUrlConfig()
-    {
-        global $shopUrlConfig;
-
-        return file_put_contents(_PS_ROOT_DIR_.$this->def['path'],
-            "<?php\n\n".
-            'global $shopUrlConfig;'."\n\n".
-            '$shopUrlConfig = '.var_export($shopUrlConfig, true).';'."\n");
     }
 
     /**

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -176,20 +176,27 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
-     * Get list of shop urls
+     * Get list of shop urls. For getting just the data, use ShopUrl::get().
      *
-     * @param bool $idShop
+     * @param bool|int $idShop
      *
-     * @return PrestaShopCollection Collection of ShopUrl
+     * @return array Array of ShopUrl objects.
      *
      * @since   1.0.0
      * @version 1.0.0 Initial version
+     * @version 1.1.0 Return array instead of a PrestaShopCollection.
      */
     public static function getShopUrls($idShop = false)
     {
-        $urls = new PrestaShopCollection('ShopUrl');
-        if ($idShop) {
-            $urls->where('id_shop', '=', $idShop);
+        global $shopUrlConfig;
+
+        $urls = [];
+        if (is_array($shopUrlConfig)) {
+            foreach ($shopUrlConfig as $id => $url) {
+                if (!$idShop || $url['id_shop'] == $idShop) {
+                    $urls[] = new ShopUrl($id);
+                }
+            }
         }
 
         return $urls;

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -93,6 +93,32 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
+     * Deletes all URLs of a shop.
+     *
+     * @param string $idShop
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function deleteShopUrls($idShop)
+    {
+        global $shopUrlConfig;
+
+        if (is_array($shopUrlConfig)) {
+            foreach ($shopUrlConfig as $key => $url) {
+                if ($url['id_shop'] == $idShop) {
+                    unset($shopUrlConfig[$key]);
+                }
+            }
+        }
+
+        (new ShopUrl)->write();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
+    }
+
+    /**
      * @see     ObjectModel::getFields()
      * @return array
      *

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -228,8 +228,18 @@ class ShopUrlCore extends ObjectModel
 			WHERE main = 1
 			AND id_shop = '.($idShop !== null ? (int) $idShop : (int) Context::getContext()->shop->id)
             );
-            static::$main_domain[(int) $idShop] = $row['domain'];
-            static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+
+            // Adjust automatic values.
+            if ($row['domain'] === '*automatic*') {
+                static::$main_domain[(int)$idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain[(int)$idShop] = $row['domain'];
+            }
+            if ($row['domain_ssl'] === '*automatic*') {
+                static::$main_domain_ssl[(int)$idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain_ssl[(int)$idShop] = $row['domain_ssl'];
+            }
         }
     }
 

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -289,27 +289,33 @@ class ShopUrlCore extends ObjectFileModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function cacheMainDomainForShop($idShop)
+    public static function cacheMainDomainForShop($idShop = null)
     {
-        if (!isset(static::$main_domain_ssl[(int) $idShop]) || !isset(static::$main_domain[(int) $idShop])) {
-            $row = Db::getInstance()->getRow(
-                '
-			SELECT domain, domain_ssl
-			FROM '._DB_PREFIX_.'shop_url
-			WHERE main = 1
-			AND id_shop = '.($idShop !== null ? (int) $idShop : (int) Context::getContext()->shop->id)
-            );
+        global $shopUrlConfig;
 
-            // Adjust automatic values.
-            if ($row['domain'] === '*automatic*') {
-                static::$main_domain[(int)$idShop] = $_SERVER['HTTP_HOST'];
-            } else {
-                static::$main_domain[(int)$idShop] = $row['domain'];
+        if (is_array($shopUrlConfig) &&
+            (!isset(static::$main_domain_ssl[(int) $idShop]) ||
+             !isset(static::$main_domain[(int) $idShop]))) {
+            $idShopNotNull = $idShop;
+            if ($idShopNotNull === null) {
+                $idShopNotNull = Context::getContext()->shop->id;
             }
-            if ($row['domain_ssl'] === '*automatic*') {
-                static::$main_domain_ssl[(int)$idShop] = $_SERVER['HTTP_HOST'];
-            } else {
-                static::$main_domain_ssl[(int)$idShop] = $row['domain_ssl'];
+
+            foreach ($shopUrlConfig as $url) {
+                if ($url['id_shop'] == $idShopNotNull && $url['main']) {
+                    // Adjust automatic values.
+                    if ($url['domain'] === '*automatic*') {
+                        static::$main_domain[(int)$idShop] = $_SERVER['HTTP_HOST'];
+                    } else {
+                        static::$main_domain[(int)$idShop] = $url['domain'];
+                    }
+                    if ($url['domain_ssl'] === '*automatic*') {
+                        static::$main_domain_ssl[(int)$idShop] = $_SERVER['HTTP_HOST'];
+                    } else {
+                        static::$main_domain_ssl[(int)$idShop] = $url['domain_ssl'];
+                    }
+                    break;
+                }
             }
         }
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -237,18 +237,23 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
+     * Test wether a combination of domain, physical URI and virtual URI
+     * exists already.
+     *
      * @param $domain
      * @param $domainSsl
      * @param $physicalUri
      * @param $virtualUri
      *
-     * @return false|null|string
+     * @return bool True = URL exists already, False = URL doesn't exit yet.
      *
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
     public function canAddThisUrl($domain, $domainSsl, $physicalUri, $virtualUri)
     {
+        global $shopUrlConfig;
+
         $physicalUri = trim($physicalUri, '/');
 
         if ($physicalUri) {
@@ -262,14 +267,20 @@ class ShopUrlCore extends ObjectFileModel
             $virtualUri = preg_replace('#/+#', '/', trim($virtualUri, '/')).'/';
         }
 
-        $sql = 'SELECT id_shop_url
-				FROM '._DB_PREFIX_.'shop_url
-				WHERE physical_uri = \''.pSQL($physicalUri).'\'
-					AND virtual_uri = \''.pSQL($virtualUri).'\'
-					AND (domain = \''.pSQL($domain).'\' '.(($domainSsl) ? ' OR domain_ssl = \''.pSQL($domainSsl).'\'' : '').')'
-            .($this->id ? ' AND id_shop_url != '.(int) $this->id : '');
+        $exists = false;
+        if (is_array($shopUrlConfig)) {
+            foreach ($shopUrlConfig as $url) {
+                if ($url['physical_uri'] === $physicalUri &&
+                    $url['virtual_uri'] === $virtualUri &&
+                    ($url['domain'] === $domain || $url['domain_ssl'] === $domainSsl)) {
 
-        return Db::getInstance()->getValue($sql);
+                    $exists = true;
+                    break;
+                }
+            }
+        }
+
+        return $exists;
     }
 
     /**

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -74,39 +74,6 @@ class ShopUrlCore extends ObjectFileModel
     ];
 
     /**
-     * This shall help with the transition from using a database table to
-     * using an PHP array written to a file. It copies DB content to
-     * the global configuration array.
-     *
-     * This method can go away as soon as this class is no longer inherited
-     * from ObjectModel. By then we have to have some other means to write
-     * the array, of course.
-     */
-    public function update($null_values = false)
-    {
-        global $shopUrlConfig;
-
-        $result = parent::update($null_values);
-
-        // Make sure each shop in the database is also in shopUrlConfig. This
-        // task can be removed as soon as shop changes are stored in
-        // shopUrlConfig by calling code.
-        $sql = 'SELECT id_shop_url, id_shop, domain, domain_ssl, physical_uri, virtual_uri, main, active
-                FROM '._DB_PREFIX_.'shop_url';
-        $sqlResult = Db::getInstance()->executeS($sql);
-
-        $shopUrlConfig = array();
-        foreach ($sqlResult as $url) {
-            $shopUrlConfig[$url['id_shop_url']] = $url;
-            unset($shopUrlConfig[$url['id_shop_url']]['id_shop_url']);
-        }
-
-        $this->write();
-
-        return $result;
-    }
-
-    /**
      * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
      * expected to be temporary, only.
      */

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -53,7 +53,15 @@ class ShopUrlCore extends ObjectFileModel
      * @see ObjectModel::$definition
      */
     public static $definition = [
-        'table'   => 'shop_url',
+        // Note: 'table' and 'primary' aren't really needed for file based
+        // storage. However, parent and related classes sometimes rely on the
+        // assumption of database based storage and also use these properties
+        // as kind of an identifier, so these properties are kept.
+        //
+        // For file based storage, we choose 'table' to be the variable name
+        // written to the file. 'primary' is replaced by the index of the table
+        // in that file.
+        'table'   => 'shopUrlConfig',
         'primary' => 'id_shop_url',
         'path'    => '/config/shop.inc.php',
         'fields'  => [
@@ -72,25 +80,6 @@ class ShopUrlCore extends ObjectFileModel
             'id_shop' => ['xlink_resource' => 'shops'],
         ],
     ];
-
-    /**
-     * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
-     * expected to be temporary, only.
-     */
-    public static function push()
-    {
-        global $shopUrlConfig;
-
-        // To make sure we also drop records no longer existing, we drop the
-        // entire table and write a fresh one. Performance is no issue here.
-        Db::getInstance()->delete('shop_url');
-
-        foreach ($shopUrlConfig as $key => $url) {
-            $url['id_shop_url'] = $key;
-
-            Db::getInstance()->insert('shop_url', $url);
-        }
-    }
 
     /**
      * Deletes all URLs of a shop.
@@ -113,9 +102,6 @@ class ShopUrlCore extends ObjectFileModel
         }
 
         (new ShopUrl)->write();
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push();
     }
 
     /**
@@ -229,9 +215,6 @@ class ShopUrlCore extends ObjectFileModel
         $this->main = true;
 
         $this->write();
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push();
 
         return $res;
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -210,21 +210,28 @@ class ShopUrlCore extends ObjectFileModel
      */
     public function setMain()
     {
-        $res = Db::getInstance()->update('shop_url', ['main' => 0], 'id_shop = '.(int) $this->id_shop);
-        $res &= Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = '.(int) $this->id);
+        global $shopUrlConfig;
+
+        $res = false;
+        if (is_array($shopUrlConfig)) {
+            foreach ($shopUrlConfig as $id => &$url) {
+                if ($url['id_shop'] == $this->id_shop) {
+                    if ($id == $this->id) {
+                        $url['main'] = 1;
+                        $res = true;
+                    } else {
+                        $url['main'] = 0;
+                    }
+                }
+            }
+            unset($url);
+        }
         $this->main = true;
 
-        // Reset main URL for all shops to prevent problems
-        $sql = 'SELECT s1.id_shop_url FROM '._DB_PREFIX_.'shop_url s1
-				WHERE (
-					SELECT COUNT(*) FROM '._DB_PREFIX_.'shop_url s2
-					WHERE s2.main = 1
-					AND s2.id_shop = s1.id_shop
-				) = 0
-				GROUP BY s1.id_shop';
-        foreach (Db::getInstance()->executeS($sql) as $row) {
-            Db::getInstance()->update('shop_url', ['main' => 1], 'id_shop_url = '.$row['id_shop_url']);
-        }
+        $this->write();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
 
         return $res;
     }

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -155,7 +155,7 @@ class AdminMetaControllerCore extends AdminController
         if (!Shop::isFeatureActive()) {
             $this->url = ShopUrl::getShopUrls($this->context->shop->id)->where('main', '=', 1)->getFirst();
             if ($this->url) {
-                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.');
+                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let PrestaShop detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [
                     'domain'     => [
                         'title'        => $this->l('Shop domain'),

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -153,7 +153,11 @@ class AdminMetaControllerCore extends AdminController
         ];
 
         if (!Shop::isFeatureActive()) {
-            $this->url = ShopUrl::getShopUrls($this->context->shop->id)->where('main', '=', 1)->getFirst();
+            foreach (ShopUrl::getShopUrls($this->context->shop->id) as $this->url) {
+                if ($this->url->main) {
+                    break;
+                }
+            }
             if ($this->url) {
                 $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let PrestaShop detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -830,12 +830,27 @@ class AdminShopControllerCore extends AdminController
     public function ajaxProcessTree()
     {
         $tree = [];
-        $sql = 'SELECT g.id_shop_group, g.name as group_name, s.id_shop, s.name as shop_name, u.id_shop_url, u.domain, u.physical_uri, u.virtual_uri
+        $sql = 'SELECT g.id_shop_group, g.name as group_name, s.id_shop, s.name as shop_name
 				FROM '._DB_PREFIX_.'shop_group g
 				LEFT JOIN  '._DB_PREFIX_.'shop s ON g.id_shop_group = s.id_shop_group
-				LEFT JOIN  '._DB_PREFIX_.'shop_url u ON u.id_shop = s.id_shop
-				ORDER BY g.name, s.name, u.domain';
-        $results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+				ORDER BY g.name, s.name';
+        $shopResults = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+
+        // Add URLs and duplicate shops with mutliple URLs.
+        $results = [];
+        $allUrls = ShopUrl::get();
+        foreach ($shopResults as $shop) {
+            foreach ($allUrls as $id => $url) {
+                if ($shop['id_shop'] == $url['id_shop']) {
+                    $shop['id_shop_url'] = $id;
+                    $shop['domain'] = $url['domain'];
+                    $shop['physical_uri'] = $url['physical_uri'];
+                    $shop['virtual_uri'] = $url['virtual_uri'];
+                    $results[] = $shop;
+                }
+            }
+        }
+
         foreach ($results as $row) {
             $idShopGroup = $row['id_shop_group'];
             $idShop = $row['id_shop'];

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -123,7 +123,14 @@ class AdminShopUrlControllerCore extends AdminController
      */
     public function renderList()
     {
-        $this->addRowActionSkipList('delete', [1]);
+        $mainUrls = [];
+        foreach (ShopUrl::get() as $key => $url) {
+            if ($url['main']) {
+                $mainUrls[] = $key;
+            }
+        }
+
+        $this->addRowActionSkipList('delete', $mainUrls);
 
         $this->addRowAction('edit');
         $this->addRowAction('delete');

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -145,12 +145,10 @@ class AdminShopUrlControllerCore extends AdminController
      */
     public function getList($idLang, $orderBy = null, $orderWay = null, $start = 0, $limit = null, $idLangShop = false)
     {
-        global $shopUrlConfig;
-
         $this->dispatchFieldsListingModifierEvent();
 
         // Get a model copy.
-        $this->_list = $shopUrlConfig;
+        $this->_list = $this->className::get();
 
         // While we can get the main list from the model (ShopUrl) we need a
         // DB query anyways, because shop names aren't stored in the model.

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -149,30 +149,6 @@ class AdminShopUrlControllerCore extends AdminController
 
         $this->dispatchFieldsListingModifierEvent();
 
-        // Start ordering section. Copied from AdminController:getList().
-        // @TODO: such stuff should be available as a seperate method in AdminController.
-        $prefix = str_replace(['admin', 'controller'], '', Tools::strtolower(get_class($this)));
-        if ($this->context->cookie->{$prefix.$this->list_id.'Orderby'}) {
-            $orderBy = $this->context->cookie->{$prefix.$this->list_id.'Orderby'};
-        } elseif ($this->_orderBy) {
-            $orderBy = $this->_orderBy;
-        } else {
-            $orderBy = $this->_defaultOrderBy;
-        }
-
-        if ($this->context->cookie->{$prefix.$this->list_id.'Orderway'}) {
-            $orderWay = $this->context->cookie->{$prefix.$this->list_id.'Orderway'};
-        } elseif ($this->_orderWay) {
-            $orderWay = $this->_orderWay;
-        } else {
-            $orderWay = $this->_defaultOrderWay;
-        }
-
-        if (!isset($this->fields_list[$orderBy]['order_key']) && isset($this->fields_list[$orderBy]['filter_key'])) {
-            $this->fields_list[$orderBy]['order_key'] = $this->fields_list[$orderBy]['filter_key'];
-        }
-        // End ordering section.
-
         // Get a model copy.
         $this->_list = $shopUrlConfig;
 
@@ -205,8 +181,7 @@ class AdminShopUrlControllerCore extends AdminController
         $this->_listTotal = count($this->_list);
 
         // Sorting/Ordering.
-        $this->_orderBy = $orderBy;
-        $this->_orderWay = strtoupper($orderWay);
+        $this->computeListOrdering();
         usort($this->_list, array('self', 'compareByArrayValues'));
 
         Hook::exec(

--- a/install-dev/data/db_schema.sql
+++ b/install-dev/data/db_schema.sql
@@ -2596,24 +2596,6 @@ CREATE TABLE IF NOT EXISTS `PREFIX_shop` (
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE utf8mb4_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS `PREFIX_shop_url` (
-  `id_shop_url`  INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `id_shop`      INT(11) UNSIGNED NOT NULL,
-  `domain`       VARCHAR(150)     NOT NULL,
-  `domain_ssl`   VARCHAR(150)     NOT NULL,
-  `physical_uri` VARCHAR(64)      NOT NULL,
-  `virtual_uri`  VARCHAR(64)      NOT NULL,
-  `main`         TINYINT(1)       NOT NULL,
-  `active`       TINYINT(1)       NOT NULL,
-  PRIMARY KEY (`id_shop_url`),
-  KEY `id_shop` (`id_shop`, `main`),
-  UNIQUE KEY `full_shop_url` (`domain`, `physical_uri`, `virtual_uri`),
-  UNIQUE KEY `full_shop_url_ssl` (`domain_ssl`, `physical_uri`, `virtual_uri`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  DEFAULT COLLATE utf8mb4_unicode_ci;
-
 CREATE TABLE IF NOT EXISTS `PREFIX_theme` (
   `id_theme`             INT(11)          NOT NULL AUTO_INCREMENT,
   `name`                 VARCHAR(64)      NOT NULL,

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -341,7 +341,7 @@ class InstallModelInstall extends InstallAbstractModel
         $shopUrl->main = true;
         $shopUrl->active = true;
         if (!$shopUrl->add()) {
-            $this->setError($this->language->l('Cannot create shop URL').' / '.Db::getInstance()->getMsgError());
+            $this->setError($this->language->l('Cannot create shop URL'));
 
             return false;
         }

--- a/tests/_support/override/classes/ObjectFileModel.php
+++ b/tests/_support/override/classes/ObjectFileModel.php
@@ -1,0 +1,7 @@
+<?php
+
+abstract class ObjectFileModel extends ObjectFileModelCore
+{
+
+}
+

--- a/tests/_support/unitloadclasses.php
+++ b/tests/_support/unitloadclasses.php
@@ -10,6 +10,8 @@ $kernel->loadFile(__DIR__.'/override/classes/Validate.php');
 $kernel->loadFile(__DIR__.'/../../Core/Foundation/Database/Core_Foundation_Database_EntityInterface.php');
 $kernel->loadFile(__DIR__.'/../../classes/ObjectModel.php');
 $kernel->loadFile(__DIR__.'/override/classes/ObjectModel.php');
+$kernel->loadFile(__DIR__.'/../../classes/ObjectFileModel.php');
+$kernel->loadFile(__DIR__.'/override/classes/ObjectFileModel.php');
 $kernel->loadFile(__DIR__.'/../../classes/CartRule.php');
 $kernel->loadFile(__DIR__.'/override/classes/CartRule.php');
 $kernel->loadFile(__DIR__.'/../../classes/Cart.php');


### PR DESCRIPTION
Here we go. This series of commits does:

- Enable *automatic* shop domains. Using them never redirects to the "right" domain, it just loads the shop as-is (1 commit).
- Replace database table ```shop_url``` with file based storage. File is config/shop.inc.php. This is not only faster due to fewer database acesses, it also makes shop domains and URLs easily accessible to shell scripts, in particular shop synchronisation scripts (25 commits, each of them can be tested by running a shop).
- Fix a bug which allowed to delete the main URL of a shop. Deleting main URLs is a bad idea for obvious reasons.

Rebased to current master, tested many many times and found to work flawlessly.

Forum discussion: https://forum.thirtybees.com/topic/76/safe-maintenance-strategy-shop-cloning/14