### PR TITLE
Remove PS_SHOP_DOMAIN and PS_SHOP_DOMAIN_SSL

### DIFF
--- a/classes/AdminTab.php
+++ b/classes/AdminTab.php
@@ -2609,10 +2609,10 @@ abstract class AdminTabCore
      */
     protected function warnDomainName()
     {
-        if ($_SERVER['HTTP_HOST'] != Configuration::get('PS_SHOP_DOMAIN') && $_SERVER['HTTP_HOST'] != Configuration::get('PS_SHOP_DOMAIN_SSL')) {
+        if ($_SERVER['HTTP_HOST'] != ShopUrl::getDefaultUrl()->domain && $_SERVER['HTTP_HOST'] != ShopUrl::getDefaultUrl()->domain) {
             $this->displayWarning(
                 $this->l('You are currently connected with the following domain name:').' <span style="color: #CC0000;">'.$_SERVER['HTTP_HOST'].'</span><br />'.
-                $this->l('This one is different from the main shop\'s domain name set in "Preferences > SEO & URLs":').' <span style="color: #CC0000;">'.Configuration::get('PS_SHOP_DOMAIN').'</span><br />
+                $this->l('This one is different from the main shop\'s domain name set in "Preferences > SEO & URLs":').' <span style="color: #CC0000;">'.ShopUrl::getDefaultUrl()->domain.'</span><br />
 			<a href="index.php?tab=AdminMeta&token='.Tools::getAdminTokenLite('AdminMeta').'#SEO%20%26%20URLs">'.
                 $this->l('Click here if you want to modify the main shop\'s domain name').'</a>'
             );

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -453,14 +453,6 @@ class ConfigurationCore extends ObjectModel
                 static::$_cache[static::$definition['table']][$lang]['global'][$row['name']] = $row['value'];
             }
         }
-
-        // Adjust automatic values.
-        if (static::get('PS_SHOP_DOMAIN') === '*automatic*') {
-            static::set('PS_SHOP_DOMAIN', $_SERVER['HTTP_HOST']);
-        }
-        if (static::get('PS_SHOP_DOMAIN_SSL') === '*automatic*') {
-            static::set('PS_SHOP_DOMAIN_SSL', $_SERVER['HTTP_HOST']);
-        }
     }
 
     /**
@@ -720,14 +712,6 @@ class ConfigurationCore extends ObjectModel
                     );
                 }
             }
-        }
-
-        // Adjust automatic values.
-        if ($key === 'PS_SHOP_DOMAIN' && in_array('*automatic*', $values)) {
-            $values = $_SERVER['HTTP_HOST'];
-        }
-        if ($key === 'PS_SHOP_DOMAIN_SSL' && in_array('*automatic*', $values)) {
-            $values = $_SERVER['HTTP_HOST'];
         }
 
         Configuration::set($key, $values, $idShopGroup, $idShop);

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -210,8 +210,6 @@ class ConfigurationCore extends ObjectModel
     const STATS_OLD_CONNECT_AUTO_CLEAN = 'PS_STATS_OLD_CONNECT_AUTO_CLEAN';
     const STATS_GRID_RENDER = 'PS_STATS_GRID_RENDER';
     const BASE_DISTANCE_UNIT = 'PS_BASE_DISTANCE_UNIT';
-    const SHOP_DOMAIN = 'PS_SHOP_DOMAIN';
-    const SHOP_DOMAIN_SSL = 'PS_SHOP_DOMAIN_SSL';
     const SHOP_NAME = 'PS_SHOP_NAME';
     const SHOP_EMAIL = 'PS_SHOP_EMAIL';
     const MAIL_METHOD = 'PS_MAIL_METHOD';
@@ -389,9 +387,11 @@ class ConfigurationCore extends ObjectModel
         // Backwards compatibility for deprecated keys.
         $domain = false;
         if ($key === 'PS_SHOP_DOMAIN') {
+            Tools::displayParameterAsDeprecated('PS_SHOP_DOMAIN');
             $domain = ShopUrl::getDefaultUrl()->domain;
         }
         if ($key === 'PS_SHOP_DOMAIN_SSL') {
+            Tools::displayParameterAsDeprecated('PS_SHOP_DOMAIN_SSL');
             $domain = ShopUrl::getDefaultUrl()->domain_ssl;
         }
         if ($domain === '*automatic*') {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1624,17 +1624,6 @@ class ToolsCore
     }
 
     /**
-     * Truncate strings
-     *
-     * @param string $str
-     * @param int    $max_length Max length
-     * @param string $suffix     Suffix optional
-     *
-     * @return string $str truncated
-     */
-    /* CAUTION : Use it only on module hookEvents.
-    ** For other purposes use the smarty function instead */
-    /**
      * getHttpHost return the <b>current</b> host used, with the protocol (http or https) if $http is true
      * This function should not be used to choose http or https domain name.
      * Use Tools::getShopDomain() or Tools::getShopDomainSsl instead

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -404,7 +404,6 @@ class ShopCore extends ObjectModel
 
     /**
      * Find the shop from current domain / uri and get an instance of this shop
-     * if INSTALL_VERSION is defined, will return an empty shop object
      *
      * @return Shop
      *

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -189,6 +189,34 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
+     * Get the default shop URL, which is the first defined main URL.
+     *
+     * @return bool|ShopUrl ShopUrl object or false on failure to find one.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function getDefaultUrl()
+    {
+        global $shopUrlConfig;
+
+        $result = false;
+        if (is_array($shopUrlConfig)) {
+            foreach ($shopUrlConfig as $id => $url) {
+                // We could also check $url['active'] here, but the GUI
+                // (AdminShopUrlController) disallows to disable the main URL,
+                // so the main URL is always active, unless tweaked manually.
+                if ($url['main']) {
+                    $result = new ShopUrl($id);
+                }
+                break;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * @return bool
      *
      * @since   1.0.0

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -153,11 +153,7 @@ class AdminMetaControllerCore extends AdminController
         ];
 
         if (!Shop::isFeatureActive()) {
-            foreach (ShopUrl::getShopUrls($this->context->shop->id) as $this->url) {
-                if ($this->url->main) {
-                    break;
-                }
-            }
+            $this->url = ShopUrl::getDefaultUrl();
             if ($this->url) {
                 $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let PrestaShop detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -468,8 +468,9 @@ class AdminMetaControllerCore extends AdminController
     public function postProcess()
     {
         /* PrestaShop demo mode */
-        if (_PS_MODE_DEMO_ && Tools::isSubmit('submitOptionsmeta')
-            && (Tools::getValue('domain') != Configuration::get('PS_SHOP_DOMAIN') || Tools::getValue('domain_ssl') != Configuration::get('PS_SHOP_DOMAIN_SSL'))) {
+        if (_PS_MODE_DEMO_ && Tools::isSubmit('submitOptionsmeta') &&
+            (Tools::getValue('domain') != ShopUrl::getDefaultUrl()->domain ||
+             Tools::getValue('domain_ssl') != ShopUrl::getDefaultUrl()->domain_ssl)) {
             $this->errors[] = Tools::displayError('This functionality has been disabled.');
 
             return null;
@@ -823,7 +824,6 @@ class AdminMetaControllerCore extends AdminController
             if (Validate::isCleanHtml($value)) {
                 $this->url->domain = $value;
                 $this->url->update();
-                Configuration::updateGlobalValue('PS_SHOP_DOMAIN', $value);
             } else {
                 $this->errors[] = Tools::displayError('This domain is not valid.');
             }
@@ -845,7 +845,6 @@ class AdminMetaControllerCore extends AdminController
             if (Validate::isCleanHtml($value)) {
                 $this->url->domain_ssl = $value;
                 $this->url->update();
-                Configuration::updateGlobalValue('PS_SHOP_DOMAIN_SSL', $value);
             } else {
                 $this->errors[] = Tools::displayError('The SSL domain is not valid.');
             }

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -709,12 +709,6 @@
     <configuration id="PS_BASE_DISTANCE_UNIT" name="PS_BASE_DISTANCE_UNIT">
       <value>m</value>
     </configuration>
-    <configuration id="PS_SHOP_DOMAIN" name="PS_SHOP_DOMAIN">
-      <value>localhost</value>
-    </configuration>
-    <configuration id="PS_SHOP_DOMAIN_SSL" name="PS_SHOP_DOMAIN_SSL">
-      <value>localhost</value>
-    </configuration>
     <configuration id="PS_SHOP_NAME" name="PS_SHOP_NAME">
       <value>PrestaShop</value>
     </configuration>

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -591,8 +591,6 @@ class InstallModelInstall extends InstallAbstractModel
         $idCountry = (int) Country::getByIso($data['shopCountry']);
 
         // Set default configuration
-        Configuration::updateGlobalValue('PS_SHOP_DOMAIN', Tools::getHttpHost());
-        Configuration::updateGlobalValue('PS_SHOP_DOMAIN_SSL', Tools::getHttpHost());
         Configuration::updateGlobalValue('PS_INSTALL_VERSION', _TB_INSTALL_VERSION_);
         Configuration::updateGlobalValue('PS_LOCALE_LANGUAGE', $this->language->getLanguageIso());
         Configuration::updateGlobalValue('PS_SHOP_NAME', $data['shopName']);


### PR DESCRIPTION
Next step towards shop snychonizability is to get rid of configuration parameters PS_SHOP_DOMAIN and PS_SHOP_DOMAIN_SSL. My impression is, they're deprecated in favor of asking ShopUrl already, this move just wasn't completed, yet.

Anyways, here are 7 commits for removing them entirely, plus one commit removing some disconnected comments I found while searching around.

While there's code establishing backwards compatibility, modules authorizeaim and cronjobs should be fixed, too. Fixes are simple, see commit comment here: https://github.com/thirtybees/ThirtyBees/commit/0614b131da05623c60ba1fe2f74dd23fa53cd626