### PR TITLE
File based ShopUrl, take two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ composer.lock
 
 /config/settings.inc.php
 /config/settings.old.php
+/config/shop.inc.php
 /config/xml/*
 /!config/xml/themes/default.xml
 

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -435,6 +435,14 @@ class ConfigurationCore extends ObjectModel
                 static::$_cache[static::$definition['table']][$lang]['global'][$row['name']] = $row['value'];
             }
         }
+
+        // Adjust automatic values.
+        if (static::get('PS_SHOP_DOMAIN') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN', $_SERVER['HTTP_HOST']);
+        }
+        if (static::get('PS_SHOP_DOMAIN_SSL') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN_SSL', $_SERVER['HTTP_HOST']);
+        }
     }
 
     /**
@@ -673,6 +681,14 @@ class ConfigurationCore extends ObjectModel
                     );
                 }
             }
+        }
+
+        // Adjust automatic values.
+        if ($key === 'PS_SHOP_DOMAIN' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
+        }
+        if ($key === 'PS_SHOP_DOMAIN_SSL' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
         }
 
         Configuration::set($key, $values, $idShopGroup, $idShop);

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -237,9 +237,6 @@ abstract class ObjectFileModelCore extends ObjectModel
         // Array insertion.
         $storage[$newId] = $fields;
         $result = static::writeStorage($storage);
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push($storage);
 
         $this->id = $newId;
 
@@ -297,9 +294,6 @@ abstract class ObjectFileModelCore extends ObjectModel
         $storage = static::getStorage();
         $storage[$this->id] = $fields;
         $result = static::writeStorage($storage);
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push($storage);
 
         /* Associations, multilingual fields not yet implemented. */
 
@@ -330,9 +324,6 @@ abstract class ObjectFileModelCore extends ObjectModel
         $storage = static::getStorage();
         unset($storage[$this->id]);
         $result = static::writeStorage($storage);
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push($storage);
 
         // @hook actionObject*DeleteAfter
         Hook::exec('actionObjectDeleteAfter', ['object' => $this]);

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -217,4 +217,39 @@ abstract class ObjectFileModelCore extends ObjectModel
 
         return $result;
     }
+
+    /**
+     * Deletes current object from the file based storage.
+     *
+     * @return bool True if delete was successful
+     * @throws PrestaShopException
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function delete()
+    {
+        $storageName = static::$definition['storage'];
+        global ${$storageName};
+
+        // @hook actionObject*DeleteBefore
+        Hook::exec('actionObjectDeleteBefore', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'DeleteBefore', ['object' => $this]);
+
+        /* Associations, multilingual fields not yet implemented. */
+
+        if (is_array(${$storageName})) {
+            unset(${$storageName}[$this->id]);
+        }
+        $result = static::writeStorage();
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push();
+
+        // @hook actionObject*DeleteAfter
+        Hook::exec('actionObjectDeleteAfter', ['object' => $this]);
+        Hook::exec('actionObject'.get_class($this).'DeleteAfter', ['object' => $this]);
+
+        return $result;
+    }
 }

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * 2017 Thirty Bees
+ *
+ * Thirty Bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017 Thirty Bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ *  @author    Thirty Bees <contact@thirtybees.com>
+ *  @copyright 2017 Thirty Bees
+ *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * This class is a shim between class ObjectModel and a class using ObjectModel.
+ * It's purpose is to not access database storage, but a regular file instead.
+ * Accordingly, all methods accessing the DB are overridden; everything else
+ * is left for the parent.
+ *
+ * Storing data in a file is useful for e.g. configuration data (read often,
+ * changed rarely). It also allows to change data by a shell script, which is
+ * crucial for shop synchronisation.
+ */
+
+// This file might not exist. For example, at install time it doesn't.
+// Accordingly, we also have to check for the existence of $shopUrlConfig
+// on every read access.
+@include_once(_PS_ROOT_DIR_.'/config/shop.inc.php');
+
+/**
+ * Class ObjectFileModelCore
+ *
+ * This class is a shim between ObjectModel and inherited classes like
+ * ShopUrlCore, which redirects storage to a file instead of the database.
+ *
+ * @since 1.1.0
+ */
+abstract class ObjectFileModelCore extends ObjectModel
+{
+    /**
+     * Builds the object
+     *
+     * @param int|null $id     If specified, loads and existing object from DB (optional).
+     * @param int|null $idLang Required if object is multilingual (optional).
+     * @param int|null $idShop ID shop for objects with multishop tables.
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public function __construct($id = null, $idLang = null, $idShop = null)
+    {
+        $storageName = static::$definition['storage'];
+        global ${$storageName};
+
+        $className = get_class($this);
+        if (!isset(ObjectFileModel::$loaded_classes[$className])) {
+            $this->def = ObjectFileModel::getDefinition($className);
+            ObjectFileModel::$loaded_classes[$className] = get_object_vars($this);
+        } else {
+            foreach (ObjectFileModel::$loaded_classes[$className] as $key => $value) {
+                $this->{$key} = $value;
+            }
+        }
+
+        $storagePath = _PS_ROOT_DIR_.static::$definition['path'];
+        if (!is_writable($storagePath) && !is_writable(dirname($storagePath))) {
+            throw new PrestaShopException('Storage file '.$storagePath.' for class '.get_class($this).' not writable.');
+        }
+
+        if ($idLang !== null) {
+            $this->id_lang = (Language::getLanguage($idLang) !== false) ? $idLang : Configuration::get('PS_LANG_DEFAULT');
+        }
+
+        if ($idShop && $this->isMultishop()) {
+            $this->id_shop = (int) $idShop;
+            $this->get_shop_from_context = false;
+        }
+
+        if ($this->isMultishop() && !$this->id_shop) {
+            $this->id_shop = Context::getContext()->shop->id;
+        }
+
+        if ($id) {
+            if (is_array(${$storageName})) {
+                // This is what Adapter_EntityMapper does after database access.
+                foreach (${$storageName}[$id] as $key => $value) {
+                    if (property_exists($this, $key)) {
+                        $this->{$key} = $value;
+                    } else {
+                        unset(${$storageName}[$id][$key]);
+                    }
+                }
+            }
+            $this->id = $id;
+        }
+    }
+
+    /**
+     * Writes the whole objects array as-is to it's file. Should be executed
+     * after any permanent change to that array.
+     *
+     * @return bool Number of bytes written or false equivalent on failure.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function writeStorage()
+    {
+        $storageName = static::$definition['storage'];
+        global ${$storageName};
+
+        $result = file_put_contents(_PS_ROOT_DIR_.static::$definition['path'],
+            "<?php\n\n".
+            'global $'.$storageName.';'."\n\n".
+            '$'.$storageName.' = '.
+              var_export(${$storageName}, true).
+            ';'."\n");
+
+        // Clear most citizens in cache-mess-city. Else the include_once()
+        // above may well read an old version on the next page load.
+        Tools::clearSmartyCache();
+        Tools::clearXMLCache();
+        Cache::getInstance()->flush();
+        PageCache::flush();
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
+
+        return $result;
+    }
+}

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -70,11 +70,11 @@ abstract class ObjectFileModelCore extends ObjectModel
     public function __construct($id = null, $idLang = null, $idShop = null)
     {
         $className = get_class($this);
-        if (!isset(ObjectFileModel::$loaded_classes[$className])) {
-            $this->def = ObjectFileModel::getDefinition($className);
-            ObjectFileModel::$loaded_classes[$className] = get_object_vars($this);
+        if (!isset(static::$loaded_classes[$className])) {
+            $this->def = static::getDefinition($className);
+            static::$loaded_classes[$className] = get_object_vars($this);
         } else {
-            foreach (ObjectFileModel::$loaded_classes[$className] as $key => $value) {
+            foreach (static::$loaded_classes[$className] as $key => $value) {
                 $this->{$key} = $value;
             }
         }
@@ -214,8 +214,8 @@ abstract class ObjectFileModelCore extends ObjectModel
             $this->date_upd = date('Y-m-d H:i:s');
         }
 
+        $idShopList = Shop::getContextListShopID();
         if (Shop::isTableAssociated($this->def['table'])) {
-            $idShopList = Shop::getContextListShopID();
             if (count($this->id_shop_list) > 0) {
                 $idShopList = $this->id_shop_list;
             }

--- a/classes/ObjectFileModel.php
+++ b/classes/ObjectFileModel.php
@@ -114,6 +114,30 @@ abstract class ObjectFileModelCore extends ObjectModel
     }
 
     /**
+     * Gets one or all record(s).
+     *
+     * @param bool $id Record to get. All records if null.
+     *
+     * @return array Array with record or array with all record arrays.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function get($id = null)
+    {
+        $storageName = static::$definition['storage'];
+        global ${$storageName};
+
+        if (!is_array(${$storageName})) {
+            return [];
+        } elseif ($id) {
+            return ${$storageName}[$id];
+        } else {
+            return ${$storageName};
+        }
+    }
+
+    /**
      * Writes the whole objects array as-is to it's file. Should be executed
      * after any permanent change to that array.
      *

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -226,16 +226,16 @@ abstract class ObjectModelCore implements Core_Foundation_Database_EntityInterfa
     public function __construct($id = null, $idLang = null, $idShop = null)
     {
         $className = get_class($this);
-        if (!isset(ObjectModel::$loaded_classes[$className])) {
-            $this->def = ObjectModel::getDefinition($className);
+        if (!isset(static::$loaded_classes[$className])) {
+            $this->def = static::getDefinition($className);
             $this->setDefinitionRetrocompatibility();
             if (!Validate::isTableOrIdentifier($this->def['primary']) || !Validate::isTableOrIdentifier($this->def['table'])) {
                 throw new PrestaShopException('Identifier or table format not valid for class '.$className);
             }
 
-            ObjectModel::$loaded_classes[$className] = get_object_vars($this);
+            static::$loaded_classes[$className] = get_object_vars($this);
         } else {
-            foreach (ObjectModel::$loaded_classes[$className] as $key => $value) {
+            foreach (static::$loaded_classes[$className] as $key => $value) {
                 $this->{$key} = $value;
             }
         }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3031,30 +3031,30 @@ class ToolsCore
         }
 
         $domains = [];
-        foreach (ShopUrl::getShopUrls() as $shop_url) {
-            /** @var ShopUrl $shop_url */
-            if (!isset($domains[$shop_url->domain])) {
-                $domains[$shop_url->domain] = [];
+        foreach (ShopUrl::getStorage() as $shopUrl) {
+            /** @var ShopUrl $shopUrl */
+            if (!isset($domains[$shopUrl['domain']])) {
+                $domains[$shopUrl['domain']] = [];
             }
 
-            $domains[$shop_url->domain][] = [
-                'physical' => $shop_url->physical_uri,
-                'virtual'  => $shop_url->virtual_uri,
-                'id_shop'  => $shop_url->id_shop,
+            $domains[$shopUrl['domain']][] = [
+                'physical' => $shopUrl['physical_uri'],
+                'virtual'  => $shopUrl['virtual_uri'],
+                'id_shop'  => $shopUrl['id_shop'],
             ];
 
-            if ($shop_url->domain == $shop_url->domain_ssl) {
+            if ($shopUrl['domain'] == $shopUrl['domain_ssl']) {
                 continue;
             }
 
-            if (!isset($domains[$shop_url->domain_ssl])) {
-                $domains[$shop_url->domain_ssl] = [];
+            if (!isset($domains[$shopUrl['domain_ssl']])) {
+                $domains[$shopUrl['domain_ssl']] = [];
             }
 
-            $domains[$shop_url->domain_ssl][] = [
-                'physical' => $shop_url->physical_uri,
-                'virtual'  => $shop_url->virtual_uri,
-                'id_shop'  => $shop_url->id_shop,
+            $domains[$shopUrl['domain_ssl']][] = [
+                'physical' => $shopUrl['physical_uri'],
+                'virtual'  => $shopUrl['virtual_uri'],
+                'id_shop'  => $shopUrl['id_shop'],
             ];
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4648,4 +4648,50 @@ class AdminControllerCore extends Controller
 
         return $result;
     }
+
+    /**
+     * Compare by values of a key inside a pair of arrays. Try hard to sort
+     * numbers as numbers and strings as strings.
+     *
+     * Can be used for usort(). The key is given in $this->_orderBy. Sort
+     * direction is in $this->_orderWay as 'ASC' or 'DESC', uppercase.
+     *
+     * @param array $a
+     * @param array $b
+     *
+     * @return -1, 0, 1
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    protected function compareByArrayValues($a, $b)
+    {
+        $a = $a[$this->_orderBy];
+        $b = $b[$this->_orderBy];
+
+        // Depending on the origin of the arrays, numbers can be either actual
+        // numbers or strings with digits inside. Sometimes even mixed. Let's
+        // try our best to compare them properly, e.g. 2 > '1'.
+
+        if ((is_string($a) && (int)$a === 0) ||
+            (is_string($b) && (int)$b === 0)) {
+            // String comparison.
+            if ($this->_orderWay === 'ASC') {
+                return strcmp($b, $a);
+            } else {
+                return strcmp($a, $b);
+            }
+        }
+
+        // Number comparison.
+        if ($a == $b) {  // Intentionally not '===' here.
+            return 0;
+        }
+        if ($this->_orderWay === 'ASC') {
+            return ($a < $b) ? 1 : -1;
+        } else {
+            return ($a > $b) ? 1 : -1;
+        }
+    }
+
 }

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -680,12 +680,18 @@ class ShopCore extends ObjectModel
      */
     public function getUrls()
     {
-        $sql = 'SELECT *
-				FROM '._DB_PREFIX_.'shop_url
-				WHERE active = 1
-					AND id_shop = '.(int) $this->id;
+        $result = ShopUrl::getStorage();
+        foreach ($result as $id => &$url) {
+            // Remove the ones we don't need.
+            if ($url['id_shop'] != $this->id || !$url['active']) {
+                unset($result[$id]);
+            } else {
+                $url['id_shop_url'] = $id;
+            }
+        }
+        unset($url);
 
-        return Db::getInstance()->executeS($sql);
+        return $result;
     }
 
     /**

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -226,39 +226,47 @@ class ShopCore extends ObjectModel
      */
     public function setUrl()
     {
-        $cacheId = 'Shop::setUrl_'.(int) $this->id;
-        if (!Cache::isStored($cacheId)) {
-            $row = Db::getInstance()->getRow(
-                '
-			SELECT su.physical_uri, su.virtual_uri, su.domain, su.domain_ssl, t.id_theme, t.name, t.directory
+        static $row = null; // Trivial caching.
+
+        if (!$row) {
+            $query = '
+                SELECT t.id_theme, t.name, t.directory
 			FROM '._DB_PREFIX_.'shop s
-			LEFT JOIN '._DB_PREFIX_.'shop_url su ON (s.id_shop = su.id_shop)
 			LEFT JOIN '._DB_PREFIX_.'theme t ON (t.id_theme = s.id_theme)
 			WHERE s.id_shop = '.(int) $this->id.'
-			AND s.active = 1 AND s.deleted = 0 AND su.main = 1'
-            );
-            Cache::store($cacheId, $row);
-        } else {
-            $row = Cache::retrieve($cacheId);
+                AND s.active = 1 AND s.deleted = 0
+            ';
+            $row = Db::getInstance()->getRow($query);
         }
         if (!$row) {
+            return false;
+        }
+
+        // Find matching shop URL.
+        foreach (ShopUrl::getStorage() as $url) {
+            if ($url['id_shop'] == $this->id && $url['main']) {
+                break;
+            }
+            unset($url);
+        }
+        if (!isset($url)) {
             return false;
         }
 
         $this->theme_id = $row['id_theme'];
         $this->theme_name = $row['name'];
         $this->theme_directory = $row['directory'];
-        $this->physical_uri = $row['physical_uri'];
-        $this->virtual_uri = $row['virtual_uri'];
-        if ($row['domain'] === '*automatic*') {
+        $this->physical_uri = $url['physical_uri'];
+        $this->virtual_uri = $url['virtual_uri'];
+        if ($url['domain'] === '*automatic*') {
             $this->domain = $_SERVER['HTTP_HOST'];
         } else {
-        $this->domain = $row['domain'];
+            $this->domain = $url['domain'];
         }
-        if ($row['domain_ssl'] === '*automatic*') {
+        if ($url['domain_ssl'] === '*automatic*') {
             $this->domain_ssl = $_SERVER['HTTP_HOST'];
         } else {
-            $this->domain_ssl = $row['domain'];
+            $this->domain_ssl = $url['domain'];
         }
 
         return true;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -926,15 +926,11 @@ class ShopCore extends ObjectModel
             return false;
         }
 
-        $query = new DbQuery();
-        $query->select('domain');
-        $query->from('shop_url');
-        $query->where('main = 1');
-        $query->where('active = 1');
-        $query .= $this->addSqlRestriction(Shop::SHARE_ORDER);
         $domains = [];
-        foreach (Db::getInstance()->executeS($query) as $row) {
-            $domains[] = $row['domain'];
+        foreach (ShopUrl::getStorage() as $url) {
+            if ($url['main'] && $url['active']) {
+                $domains[] = $url['domain'];
+            }
         }
 
         return $domains;

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -499,21 +499,18 @@ class ShopCore extends ObjectModel
                 // Keeping $idShop at false means with redirection.
                 $idDefaultShop = Configuration::get('PS_SHOP_DEFAULT');
 
-                // Get this directly from the database to see '*automatic*'.
-                $sql = 'SELECT domain, domain_ssl
-                        FROM '._DB_PREFIX_.'shop_url
-                        WHERE id_shop = \''.pSQL($idDefaultShop).'\'';
-
-                $result = Db::getInstance()->executeS($sql);
-
+                foreach (ShopUrl::getStorage() as $url) {
+                    if ($url['id_shop'] == $idDefaultShop && $url['main']) {
                 if (Configuration::get('PS_SSL_ENABLED')) {
-                    if ($result[0]['domain_ssl'] === '*automatic*') {
+                            if ($url['domain_ssl'] === '*automatic*') {
                         $idShop = $idDefaultShop;
                     }
                 } else {
-                    if ($result[0]['domain'] === '*automatic*') {
+                            if ($url['domain'] === '*automatic*') {
                         $idShop = $idDefaultShop;
                     }
+                }
+            }
                 }
             }
 

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -344,7 +344,7 @@ class ShopCore extends ObjectModel
         $res &= Db::getInstance()->delete('stock_available', '`id_shop` = '.(int) $this->id);
 
         // Remove urls
-        $res &= Db::getInstance()->delete('shop_url', '`id_shop` = '.(int) $this->id);
+        ShopUrl::deleteShopUrls($this->id);
 
         // Remove currency restrictions
         $res &= Db::getInstance()->delete('module_currency', '`id_shop` = '.(int) $this->id);

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -53,7 +53,15 @@ class ShopUrlCore extends ObjectFileModel
      * @see ObjectModel::$definition
      */
     public static $definition = [
-        'table'   => 'shop_url',
+        // Note: 'table' and 'primary' aren't really needed for file based
+        // storage. However, parent and related classes sometimes rely on the
+        // assumption of database based storage and also use these properties
+        // as kind of an identifier, so these properties are kept.
+        //
+        // For file based storage, we choose 'table' to be the variable name
+        // written to the file. 'primary' is replaced by the index of the table
+        // in that file.
+        'table'   => 'shopUrlConfig',
         'primary' => 'id_shop_url',
         'path'    => '/config/shop.inc.php',
         'fields'  => [
@@ -74,23 +82,6 @@ class ShopUrlCore extends ObjectFileModel
     ];
 
     /**
-     * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
-     * expected to be temporary, only.
-     */
-    public static function push($storage)
-    {
-        // To make sure we also drop records no longer existing, we drop the
-        // entire table and write a fresh one. Performance is no issue here.
-        Db::getInstance()->delete('shop_url');
-
-        foreach ($storage as $key => $url) {
-            $url['id_shop_url'] = $key;
-
-            Db::getInstance()->insert('shop_url', $url);
-        }
-    }
-
-    /**
      * Deletes all URLs of a shop.
      *
      * @param string $idShop
@@ -109,9 +100,6 @@ class ShopUrlCore extends ObjectFileModel
         }
 
         static::writeStorage($storage);
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push($storage);
     }
 
     /**
@@ -219,9 +207,6 @@ class ShopUrlCore extends ObjectFileModel
         $this->main = true;
 
         static::writeStorage($storage);
-        // Remove later. Comment out to see wether the code here actually works,
-        // or wether DB gets written by some other means we no longer want.
-        ShopUrl::push($storage);
 
         return $res;
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -227,12 +227,15 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
+     * Test wether a combination of domain, physical URI and virtual URI
+     * exists already.
+     *
      * @param $domain
      * @param $domainSsl
      * @param $physicalUri
      * @param $virtualUri
      *
-     * @return false|null|string
+     * @return bool True = URL exists already, false = URL doesn't exit yet.
      *
      * @since   1.0.0
      * @version 1.0.0 Initial version
@@ -252,14 +255,18 @@ class ShopUrlCore extends ObjectFileModel
             $virtualUri = preg_replace('#/+#', '/', trim($virtualUri, '/')).'/';
         }
 
-        $sql = 'SELECT id_shop_url
-				FROM '._DB_PREFIX_.'shop_url
-				WHERE physical_uri = \''.pSQL($physicalUri).'\'
-					AND virtual_uri = \''.pSQL($virtualUri).'\'
-					AND (domain = \''.pSQL($domain).'\' '.(($domainSsl) ? ' OR domain_ssl = \''.pSQL($domainSsl).'\'' : '').')'
-            .($this->id ? ' AND id_shop_url != '.(int) $this->id : '');
+        $exists = false;
+        foreach (static::getStorage() as $url) {
+            if ($url['physical_uri'] === $physicalUri &&
+                $url['virtual_uri'] === $virtualUri &&
+                ($url['domain'] === $domain || $url['domain_ssl'] === $domainSsl)) {
 
-        return Db::getInstance()->getValue($sql);
+                $exists = true;
+                break;
+            }
+        }
+
+        return $exists;
     }
 
     /**

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -228,8 +228,18 @@ class ShopUrlCore extends ObjectModel
 			WHERE main = 1
 			AND id_shop = '.($idShop !== null ? (int) $idShop : (int) Context::getContext()->shop->id)
             );
-            static::$main_domain[(int) $idShop] = $row['domain'];
-            static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+
+            // Adjust automatic values.
+            if ($row['domain'] === '*automatic*') {
+                static::$main_domain[(int) $idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain[(int) $idShop] = $row['domain'];
+            }
+            if ($row['domain_ssl'] === '*automatic*') {
+                static::$main_domain_ssl[(int) $idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+            }
         }
     }
 

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -55,9 +55,7 @@ class ShopUrlCore extends ObjectFileModel
     public static $definition = [
         'table'   => 'shop_url',
         'primary' => 'id_shop_url',
-        // Has to match one of the include()'s in ObjectFileModel.
         'path'    => '/config/shop.inc.php',
-        'storage' => 'shopUrlConfig',
         'fields'  => [
             'active'       => ['type' => self::TYPE_BOOL,   'validate' => 'isBool'                                          ],
             'main'         => ['type' => self::TYPE_BOOL,   'validate' => 'isBool'                                          ],
@@ -79,21 +77,16 @@ class ShopUrlCore extends ObjectFileModel
      * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
      * expected to be temporary, only.
      */
-    public static function push()
+    public static function push($storage)
     {
-        $storageName = static::$definition['storage'];
-        global ${$storageName};
+        // To make sure we also drop records no longer existing, we drop the
+        // entire table and write a fresh one. Performance is no issue here.
+        Db::getInstance()->delete('shop_url');
 
-        if (is_array(${$storageName})) {
-            // To make sure we also drop records no longer existing, we drop the
-            // entire table and write a fresh one. Performance is no issue here.
-            Db::getInstance()->delete('shop_url');
+        foreach ($storage as $key => $url) {
+            $url['id_shop_url'] = $key;
 
-            foreach (${$storageName} as $key => $url) {
-                $url['id_shop_url'] = $key;
-
-                Db::getInstance()->insert('shop_url', $url);
-            }
+            Db::getInstance()->insert('shop_url', $url);
         }
     }
 

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -76,41 +76,6 @@ class ShopUrlCore extends ObjectFileModel
     ];
 
     /**
-     * This shall help with the transition from using a database table to
-     * using an PHP array written to a file. It copies DB content to
-     * the global configuration array.
-     *
-     * This method can go away as soon as this class is no longer inherited
-     * from ObjectModel. By then we have to have some other means to write
-     * the array, of course.
-     */
-    public function update($null_values = false)
-    {
-        $storageName = static::$definition['storage'];
-        global ${$storageName};
-
-        $result = parent::update($null_values);
-
-        // Make sure each shop in the database is also in $shopUrlConfig.
-        // This task can be removed as soon as shop changes are stored in
-        // $shopUrlConfig by calling code.
-        $sql = 'SELECT id_shop_url, id_shop, domain, domain_ssl, physical_uri, virtual_uri, main, active
-                FROM '._DB_PREFIX_.'shop_url';
-        $sqlResult = Db::getInstance()->executeS($sql);
-
-        $storage = &${$storageName};
-        $storage = array();
-        foreach ($sqlResult as $url) {
-            $storage[$url['id_shop_url']] = $url;
-            unset($storage[$url['id_shop_url']]['id_shop_url']);
-        }
-
-        static::writeStorage();
-
-        return $result;
-    }
-
-    /**
      * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
      * expected to be temporary, only.
      */

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -91,6 +91,30 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
+     * Deletes all URLs of a shop.
+     *
+     * @param string $idShop
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function deleteShopUrls($idShop)
+    {
+        $storage = static::getStorage();
+
+        foreach ($storage as $key => $url) {
+            if ($url['id_shop'] == $idShop) {
+                unset($storage[$key]);
+            }
+        }
+
+        static::writeStorage($storage);
+        // Remove later. Comment out to see wether the code here actually works,
+        // or wether DB gets written by some other means we no longer want.
+        ShopUrl::push($storage);
+    }
+
+    /**
      * @see     ObjectModel::getFields()
      * @return array
      *

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -275,27 +275,30 @@ class ShopUrlCore extends ObjectFileModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function cacheMainDomainForShop($idShop)
+    public static function cacheMainDomainForShop($idShop = null)
     {
-        if (!isset(static::$main_domain_ssl[(int) $idShop]) || !isset(static::$main_domain[(int) $idShop])) {
-            $row = Db::getInstance()->getRow(
-                '
-			SELECT domain, domain_ssl
-			FROM '._DB_PREFIX_.'shop_url
-			WHERE main = 1
-			AND id_shop = '.($idShop !== null ? (int) $idShop : (int) Context::getContext()->shop->id)
-            );
-
-            // Adjust automatic values.
-            if ($row['domain'] === '*automatic*') {
-                static::$main_domain[(int) $idShop] = $_SERVER['HTTP_HOST'];
-            } else {
-                static::$main_domain[(int) $idShop] = $row['domain'];
+        if (!isset(static::$main_domain_ssl[(int) $idShop]) ||
+            !isset(static::$main_domain[(int) $idShop])) {
+            $idShopNotNull = $idShop;
+            if ($idShopNotNull === null) {
+                $idShopNotNull = Context::getContext()->shop->id;
             }
-            if ($row['domain_ssl'] === '*automatic*') {
-                static::$main_domain_ssl[(int) $idShop] = $_SERVER['HTTP_HOST'];
-            } else {
-                static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+
+            foreach (static::getStorage() as $url) {
+                if ($url['id_shop'] == $idShopNotNull && $url['main']) {
+                    // Adjust automatic values.
+                    if ($url['domain'] === '*automatic*') {
+                        static::$main_domain[(int) $idShop] = $_SERVER['HTTP_HOST'];
+                    } else {
+                        static::$main_domain[(int) $idShop] = $url['domain'];
+                    }
+                    if ($url['domain_ssl'] === '*automatic*') {
+                        static::$main_domain_ssl[(int) $idShop] = $_SERVER['HTTP_HOST'];
+                    } else {
+                        static::$main_domain_ssl[(int) $idShop] = $url['domain_ssl'];
+                    }
+                    break;
+                }
             }
         }
     }

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -29,6 +29,11 @@
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 
+// This file might not exist. For example, at install time it doesn't.
+// Accordingly, we also have to check for the existence of $shopUrlConfig
+// on every read access.
+@include_once(_PS_ROOT_DIR_.'/config/shop.inc.php');
+
 /**
  * Class ShopUrlCore
  *
@@ -55,6 +60,7 @@ class ShopUrlCore extends ObjectModel
     public static $definition = [
         'table'   => 'shop_url',
         'primary' => 'id_shop_url',
+        'path'    => '/config/shop.inc.php', // Has to match include() above.
         'fields'  => [
             'active'       => ['type' => self::TYPE_BOOL,   'validate' => 'isBool'                                          ],
             'main'         => ['type' => self::TYPE_BOOL,   'validate' => 'isBool'                                          ],
@@ -71,6 +77,92 @@ class ShopUrlCore extends ObjectModel
             'id_shop' => ['xlink_resource' => 'shops'],
         ],
     ];
+
+    /**
+     * This shall help with the transition from using a database table to
+     * using an PHP array written to a file. It copies DB content to
+     * the global configuration array.
+     *
+     * This method can go away as soon as this class is no longer inherited
+     * from ObjectModel. By then we have to have some other means to write
+     * the array, of course.
+     */
+    public function update($null_values = false)
+    {
+        global $shopUrlConfig;
+
+        $result = parent::update($null_values);
+
+        // Make sure each shop in the database is also in $shopUrlConfig.
+        // This task can be removed as soon as shop changes are stored in
+        // $shopUrlConfig by calling code.
+        $sql = 'SELECT id_shop_url, id_shop, domain, domain_ssl, physical_uri, virtual_uri, main, active
+                FROM '._DB_PREFIX_.'shop_url';
+        $sqlResult = Db::getInstance()->executeS($sql);
+
+        $shopUrlConfig = array();
+        foreach ($sqlResult as $url) {
+            $shopUrlConfig[$url['id_shop_url']] = $url;
+            unset($shopUrlConfig[$url['id_shop_url']]['id_shop_url']);
+        }
+
+        static::writeStorage();
+
+        return $result;
+    }
+
+    /**
+     * Do the opposite of update(): forward $shopUrlConfig to the DB. Also
+     * expected to be temporary, only.
+     */
+    public static function push()
+    {
+        global $shopUrlConfig;
+
+        if (is_array($shopUrlConfig)) {
+            // To make sure we also drop records no longer existing, we drop the
+            // entire table and write a fresh one. Performance is no issue here.
+            Db::getInstance()->delete('shop_url');
+
+            foreach ($shopUrlConfig as $key => $url) {
+                $url['id_shop_url'] = $key;
+
+                Db::getInstance()->insert('shop_url', $url);
+            }
+        }
+    }
+
+    /**
+     * Write storage to the file. That's $shopUrlConfig here.
+     *
+     * @return int|bool Number of bytes written or false-equivalent on failure.
+     *
+     * @since   1.1.0
+     * @version 1.1.0 Initial version
+     */
+    public static function writeStorage()
+    {
+        global $shopUrlConfig; // Assume it exists.
+
+        $result = file_put_contents(_PS_ROOT_DIR_.static::$definition['path'],
+            "<?php\n\n".
+            'global $shopUrlConfig;'."\n\n".
+            '$shopUrlConfig = '.
+              var_export($shopUrlConfig, true).
+            ';'."\n");
+
+        // Clear most citizens in cache-mess-city. Else the include_once()
+        // above may well read an old version on the next page load.
+        Tools::clearSmartyCache();
+        Tools::clearXMLCache();
+        Cache::getInstance()->flush();
+        PageCache::flush();
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
+
+        return $result;
+    }
 
     /**
      * @see     ObjectModel::getFields()

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -29,17 +29,12 @@
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 
-// This file might not exist. For example, at install time it doesn't.
-// Accordingly, we also have to check for the existence of $shopUrlConfig
-// on every read access.
-@include_once(_PS_ROOT_DIR_.'/config/shop.inc.php');
-
 /**
  * Class ShopUrlCore
  *
  * @since 1.0.0
  */
-class ShopUrlCore extends ObjectModel
+class ShopUrlCore extends ObjectFileModel
 {
     // @codingStandardsIgnoreStart
     public $id_shop;
@@ -60,7 +55,8 @@ class ShopUrlCore extends ObjectModel
     public static $definition = [
         'table'   => 'shop_url',
         'primary' => 'id_shop_url',
-        'path'    => '/config/shop.inc.php', // Has to match include() above.
+        // Has to match one of the include()'s in ObjectFileModel.
+        'path'    => '/config/shop.inc.php',
         'storage' => 'shopUrlConfig',
         'fields'  => [
             'active'       => ['type' => self::TYPE_BOOL,   'validate' => 'isBool'                                          ],
@@ -134,39 +130,6 @@ class ShopUrlCore extends ObjectModel
                 Db::getInstance()->insert('shop_url', $url);
             }
         }
-    }
-
-    /**
-     * Write storage to the file. That's $shopUrlConfig here.
-     *
-     * @return int|bool Number of bytes written or false-equivalent on failure.
-     *
-     * @since   1.1.0
-     * @version 1.1.0 Initial version
-     */
-    public static function writeStorage()
-    {
-        $storageName = static::$definition['storage'];
-        global ${$storageName}; // Assume it exists.
-
-        $result = file_put_contents(_PS_ROOT_DIR_.static::$definition['path'],
-            "<?php\n\n".
-            'global $'.$storageName.';'."\n\n".
-            '$'.$storageName.' = '.
-              var_export(${$storageName}, true).
-            ';'."\n");
-
-        // Clear most citizens in cache-mess-city. Else the include_once()
-        // above may well read an old version on the next page load.
-        Tools::clearSmartyCache();
-        Tools::clearXMLCache();
-        Cache::getInstance()->flush();
-        PageCache::flush();
-        if (function_exists('opcache_reset')) {
-            opcache_reset();
-        }
-
-        return $result;
     }
 
     /**

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -172,20 +172,24 @@ class ShopUrlCore extends ObjectFileModel
     }
 
     /**
-     * Get list of shop urls
+     * Get list of shop URLs. For getting just the data, use
+     * ShopUrl::getStorage().
      *
-     * @param bool $idShop
+     * @param bool|int $idShop
      *
-     * @return PrestaShopCollection Collection of ShopUrl
+     * @return array Array of ShopUrl objects.
      *
      * @since   1.0.0
      * @version 1.0.0 Initial version
+     * @version 1.1.0 Return array instead of a PrestaShopCollection.
      */
     public static function getShopUrls($idShop = false)
     {
-        $urls = new PrestaShopCollection('ShopUrl');
-        if ($idShop) {
-            $urls->where('id_shop', '=', $idShop);
+        $urls = [];
+        foreach (static::getStorage() as $id => $url) {
+            if (!$idShop || $url['id_shop'] == $idShop) {
+                $urls[] = new ShopUrl($id);
+            }
         }
 
         return $urls;

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -156,7 +156,11 @@ class AdminMetaControllerCore extends AdminController
         ];
 
         if (!Shop::isFeatureActive()) {
-            $this->url = ShopUrl::getShopUrls($this->context->shop->id)->where('main', '=', 1)->getFirst();
+            foreach (ShopUrl::getShopUrls($this->context->shop->id) as $this->url) {
+                if ($this->url->main) {
+                    break;
+                }
+            }
             if ($this->url) {
                 $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let thirty bees detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -158,7 +158,7 @@ class AdminMetaControllerCore extends AdminController
         if (!Shop::isFeatureActive()) {
             $this->url = ShopUrl::getShopUrls($this->context->shop->id)->where('main', '=', 1)->getFirst();
             if ($this->url) {
-                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.');
+                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let thirty bees detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [
                     'domain'     => [
                         'title'        => $this->l('Shop domain'),

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -243,14 +243,12 @@ class AdminShopControllerCore extends AdminController
         $this->addRowAction('edit');
         $this->addRowAction('delete');
 
-        $this->_select = 'gs.name shop_group_name, cl.name category_name, CONCAT(\'http://\', su.domain, su.physical_uri, su.virtual_uri) AS url';
+        $this->_select = 'gs.name shop_group_name, cl.name category_name';
         $this->_join = '
 			LEFT JOIN `'._DB_PREFIX_.'shop_group` gs
 				ON (a.id_shop_group = gs.id_shop_group)
 			LEFT JOIN `'._DB_PREFIX_.'category_lang` cl
 				ON (a.id_category = cl.id_category AND cl.id_lang='.(int) $this->context->language->id.')
-			LEFT JOIN '._DB_PREFIX_.'shop_url su
-				ON a.id_shop = su.id_shop AND su.main = 1
 		';
         $this->_group = 'GROUP BY a.id_shop';
 
@@ -362,15 +360,28 @@ class AdminShopControllerCore extends AdminController
         }
 
         parent::getList($idLang, $orderBy, $orderWay, $start, $limit, $idLangShop);
-        $shopDeleteList = [];
 
         // don't allow to remove shop which have dependencies (customers / orders / ... )
+        $shopDeleteList = [];
         foreach ($this->_list as &$shop) {
             if (Shop::hasDependency($shop['id_shop'])) {
                 $shopDeleteList[] = $shop['id_shop'];
             }
         }
         $this->context->smarty->assign('shops_having_dependencies', $shopDeleteList);
+
+        // Add URLs.
+        $allUrls = ShopUrl::getStorage();
+        foreach ($this->_list as &$shop) {
+            foreach ($allUrls as $url) {
+                if ($shop['id_shop'] == $url['id_shop'] && $url['main']) {
+                    $shop['url']  = 'http://'. $url['domain'];
+                    $shop['url'] .= $url['physical_uri'].$url['virtual_uri'];
+                    break;
+                }
+            }
+        }
+        unset($shop);
     }
 
     /**

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -145,13 +145,10 @@ class AdminShopUrlControllerCore extends AdminController
      */
     public function getList($idLang, $orderBy = null, $orderWay = null, $start = 0, $limit = null, $idLangShop = false)
     {
-        $storageName = static::$definition['storage'];
-        global ${$storageName};
-
         $this->dispatchFieldsListingModifierEvent();
 
         // Get a model copy.
-        $this->_list = ${$storageName};
+        $this->_list = $this->className::get();
 
         // While we can get the main list from the model (ShopUrl) we need a
         // DB query anyways, because shop names aren't stored in the model.

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -148,7 +148,7 @@ class AdminShopUrlControllerCore extends AdminController
         $this->dispatchFieldsListingModifierEvent();
 
         // Get a model copy.
-        $this->_list = $this->className::get();
+        $this->_list = $this->className::getStorage();
 
         // While we can get the main list from the model (ShopUrl) we need a
         // DB query anyways, because shop names aren't stored in the model.

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -150,30 +150,6 @@ class AdminShopUrlControllerCore extends AdminController
 
         $this->dispatchFieldsListingModifierEvent();
 
-        // Start ordering section. Copied from AdminController:getList().
-        // @TODO: such stuff should be available as a seperate method in AdminController.
-        $prefix = str_replace(['admin', 'controller'], '', Tools::strtolower(get_class($this)));
-        if ($this->context->cookie->{$prefix.$this->list_id.'Orderby'}) {
-            $orderBy = $this->context->cookie->{$prefix.$this->list_id.'Orderby'};
-        } elseif ($this->_orderBy) {
-            $orderBy = $this->_orderBy;
-        } else {
-            $orderBy = $this->_defaultOrderBy;
-        }
-
-        if ($this->context->cookie->{$prefix.$this->list_id.'Orderway'}) {
-            $orderWay = $this->context->cookie->{$prefix.$this->list_id.'Orderway'};
-        } elseif ($this->_orderWay) {
-            $orderWay = $this->_orderWay;
-        } else {
-            $orderWay = $this->_defaultOrderWay;
-        }
-
-        if (!isset($this->fields_list[$orderBy]['order_key']) && isset($this->fields_list[$orderBy]['filter_key'])) {
-            $this->fields_list[$orderBy]['order_key'] = $this->fields_list[$orderBy]['filter_key'];
-        }
-        // End ordering section.
-
         // Get a model copy.
         $this->_list = ${$storageName};
 
@@ -206,8 +182,7 @@ class AdminShopUrlControllerCore extends AdminController
         $this->_listTotal = count($this->_list);
 
         // Sorting/Ordering.
-        $this->_orderBy = $orderBy;
-        $this->_orderWay = strtoupper($orderWay);
+        $this->computeListOrdering();
         usort($this->_list, array('self', 'compareByArrayValues'));
 
         Hook::exec(

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -123,7 +123,14 @@ class AdminShopUrlControllerCore extends AdminController
      */
     public function renderList()
     {
-        $this->addRowActionSkipList('delete', [1]);
+        $mainUrls = [];
+        foreach (ShopUrl::getStorage() as $key => $url) {
+            if ($url['main']) {
+                $mainUrls[] = $key;
+            }
+        }
+
+        $this->addRowActionSkipList('delete', $mainUrls);
 
         $this->addRowAction('edit');
         $this->addRowAction('delete');

--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -128,15 +128,94 @@ class AdminShopUrlControllerCore extends AdminController
         $this->addRowAction('edit');
         $this->addRowAction('delete');
 
-        $this->_select = 's.name AS shop_name, CONCAT(\'http://\', a.domain, a.physical_uri, a.virtual_uri) AS url';
-        $this->_join = 'LEFT JOIN `'._DB_PREFIX_.'shop` s ON (s.id_shop = a.id_shop)';
-
-        if ($idShop = (int) Tools::getValue('id_shop')) {
-            $this->_where = 'AND a.id_shop = '.$idShop;
-        }
-        $this->_use_found_rows = false;
-
         return parent::renderList();
+    }
+
+    /**
+     * @param int         $idLang
+     * @param string|null $orderBy
+     * @param string|null $orderWay
+     * @param int         $start
+     * @param int|null    $limit
+     * @param int|bool    $idLangShop
+     *
+     * @return void
+     *
+     * @since 1.1.0
+     */
+    public function getList($idLang, $orderBy = null, $orderWay = null, $start = 0, $limit = null, $idLangShop = false)
+    {
+        $storageName = static::$definition['storage'];
+        global ${$storageName};
+
+        $this->dispatchFieldsListingModifierEvent();
+
+        // Start ordering section. Copied from AdminController:getList().
+        // @TODO: such stuff should be available as a seperate method in AdminController.
+        $prefix = str_replace(['admin', 'controller'], '', Tools::strtolower(get_class($this)));
+        if ($this->context->cookie->{$prefix.$this->list_id.'Orderby'}) {
+            $orderBy = $this->context->cookie->{$prefix.$this->list_id.'Orderby'};
+        } elseif ($this->_orderBy) {
+            $orderBy = $this->_orderBy;
+        } else {
+            $orderBy = $this->_defaultOrderBy;
+        }
+
+        if ($this->context->cookie->{$prefix.$this->list_id.'Orderway'}) {
+            $orderWay = $this->context->cookie->{$prefix.$this->list_id.'Orderway'};
+        } elseif ($this->_orderWay) {
+            $orderWay = $this->_orderWay;
+        } else {
+            $orderWay = $this->_defaultOrderWay;
+        }
+
+        if (!isset($this->fields_list[$orderBy]['order_key']) && isset($this->fields_list[$orderBy]['filter_key'])) {
+            $this->fields_list[$orderBy]['order_key'] = $this->fields_list[$orderBy]['filter_key'];
+        }
+        // End ordering section.
+
+        // Get a model copy.
+        $this->_list = ${$storageName};
+
+        // While we can get the main list from the model (ShopUrl) we need a
+        // DB query anyways, because shop names aren't stored in the model.
+        $sql = 'SELECT id_shop, name
+                FROM '._DB_PREFIX_.'shop';
+        $sqlResult = Db::getInstance()->executeS($sql);
+
+        $idShop = Tools::getValue('id_shop');
+        foreach ($this->_list as $idShopUrl => &$row) {
+            // Remove foreign shops.
+            if ($idShop && $row['id_shop'] != $idShop) {
+                unset($this->_list[$idShopUrl]);
+                continue;
+            }
+
+            // Add computed fields.
+            $row['id_shop_url'] = $idShopUrl;
+            $row['url'] = 'http://'.$row['domain'].$row['physical_uri'].$row['virtual_uri'];
+            $row['shop_name'] = '???'; // fallback
+            foreach ($sqlResult as $shop) {
+                if ($shop['id_shop'] == $row['id_shop']) {
+                    $row['shop_name'] = $shop['name'];
+                    break;
+                }
+            }
+        }
+        unset($row);
+        $this->_listTotal = count($this->_list);
+
+        // Sorting/Ordering.
+        $this->_orderBy = $orderBy;
+        $this->_orderWay = strtoupper($orderWay);
+        usort($this->_list, array('self', 'compareByArrayValues'));
+
+        Hook::exec(
+            'action'.$this->controller_name.'ListingResultsModifier', [
+                'list'       => &$this->_list,
+                'list_total' => &$this->_listTotal,
+            ]
+        );
     }
 
     /**

--- a/install-dev/data/db_schema.sql
+++ b/install-dev/data/db_schema.sql
@@ -2596,24 +2596,6 @@ CREATE TABLE IF NOT EXISTS `PREFIX_shop` (
   DEFAULT CHARSET = utf8mb4
   DEFAULT COLLATE utf8mb4_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS `PREFIX_shop_url` (
-  `id_shop_url`  INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `id_shop`      INT(11) UNSIGNED NOT NULL,
-  `domain`       VARCHAR(150)     NOT NULL,
-  `domain_ssl`   VARCHAR(150)     NOT NULL,
-  `physical_uri` VARCHAR(64)      NOT NULL,
-  `virtual_uri`  VARCHAR(64)      NOT NULL,
-  `main`         TINYINT(1)       NOT NULL,
-  `active`       TINYINT(1)       NOT NULL,
-  PRIMARY KEY (`id_shop_url`),
-  KEY `id_shop` (`id_shop`, `main`),
-  UNIQUE KEY `full_shop_url` (`domain`, `physical_uri`, `virtual_uri`),
-  UNIQUE KEY `full_shop_url_ssl` (`domain_ssl`, `physical_uri`, `virtual_uri`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4
-  DEFAULT COLLATE utf8mb4_unicode_ci;
-
 CREATE TABLE IF NOT EXISTS `PREFIX_theme` (
   `id_theme`             INT(11)          NOT NULL AUTO_INCREMENT,
   `name`                 VARCHAR(64)      NOT NULL,

--- a/install-dev/models/install.php
+++ b/install-dev/models/install.php
@@ -341,7 +341,7 @@ class InstallModelInstall extends InstallAbstractModel
         $shopUrl->main = true;
         $shopUrl->active = true;
         if (!$shopUrl->add()) {
-            $this->setError($this->language->l('Cannot create shop URL').' / '.Db::getInstance()->getMsgError());
+            $this->setError($this->language->l('Cannot create shop URL'));
 
             return false;
         }

--- a/tests/_support/override/classes/ObjectFileModel.php
+++ b/tests/_support/override/classes/ObjectFileModel.php
@@ -1,0 +1,7 @@
+<?php
+
+abstract class ObjectFileModel extends ObjectFileModelCore
+{
+
+}
+

--- a/tests/_support/unitloadclasses.php
+++ b/tests/_support/unitloadclasses.php
@@ -10,6 +10,8 @@ $kernel->loadFile(__DIR__.'/override/classes/Validate.php');
 $kernel->loadFile(__DIR__.'/../../Core/Foundation/Database/Core_Foundation_Database_EntityInterface.php');
 $kernel->loadFile(__DIR__.'/../../classes/ObjectModel.php');
 $kernel->loadFile(__DIR__.'/override/classes/ObjectModel.php');
+$kernel->loadFile(__DIR__.'/../../classes/ObjectFileModel.php');
+$kernel->loadFile(__DIR__.'/override/classes/ObjectFileModel.php');
 $kernel->loadFile(__DIR__.'/../../classes/CartRule.php');
 $kernel->loadFile(__DIR__.'/override/classes/CartRule.php');
 $kernel->loadFile(__DIR__.'/../../classes/Cart.php');


### PR DESCRIPTION
As at least two people were uncomfortable with using a global variable, so I searched for better solutions. Searching, like implementing five of them. It's only the first step of the commit series and can only change already existing URLs in Advanced Preferences -> Multishop. Even then, content written to the file is just a copy of database content. The other 25 commits will follow after a decision about these five versions of the first commit was found.

Commit 1 is what was there before.  ShopUrls stored in global $shopUrlConfig. Name of that variable hardcoded.

Commit 2 abstracts that a bit and provides a class property for the variable name. Something compiled languages don't allow to do. This should allow to treat multiple instances of distinct storage once this code goes into a common base class similar to ObjectModel.

Commit 3 introduces a subclass for storage. Which means the global variable goes away, just to be replaced by some other global entity, a class.

Commit 4 does almost the same, but with a trait. This makes variable access a bit shorter.

Commit 5 uses include()s inside methods, making $shopUrlConfig a local variable in each method.

Commits 3, 4 and 5 don't work flawlessly, but 3 and 5 might allow to go with workarounds. Caveats are described in the commit message.

Please do your choice, folks. Further refinements are also welcome, of course.