### PR TITLE
Improved package build script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,123 @@
 #!/usr/bin/env bash
-composer install --no-dev
-find -type d -name tests -exec rm -rf {} \;
-composer dump-autoload -o
-mv admin-dev admin
-mv install-dev install
-rm -rf .git
-rm architecture.md
-rm codeception.yml
-rm .coveralls.yml
-rm .gitignore
-rm .gitmodules
-rm .scrutinizer.yml
-rm .travis.yml
-rm build.sh
-node ./tools/generatemd5list.js
+
+# This script builds an installation package from the current repository.
+
+TB_VERSION=$((cat install-dev/install_version.php &&
+              echo 'print(_TB_INSTALL_VERSION_);') | \
+             php)
+
+echo "Packaging thirty bees version ${TB_VERSION}."
+echo "Assuming all module repositories are up to date."
+
+# Create packaging directory.
+DIR=$(mktemp -d)
+trap "rm -rf ${DIR}" 0
+
+DIR+="/thirty-bees-${TB_VERSION}"
+mkdir "${DIR}"
+export DIR
+
+
+# Collect Git repositories to deal with. This is a bit slow, but parsing
+# .gitmodules directly is unreliable.
+REPOS_GIT=($(
+  git submodule | \
+    cut -b 2- | \
+    cut -d ' ' -f 2
+))
+REPOS_GIT+=(".")
+
+
+# Files not needed in the release package.
+EXCLUDE_FILE=(".coveralls.yml")
+EXCLUDE_FILE+=(".gitignore")
+EXCLUDE_FILE+=(".gitmodules")
+EXCLUDE_FILE+=(".htaccess")
+EXCLUDE_FILE+=(".scrutinizer.yml")
+EXCLUDE_FILE+=(".travis.yml")
+EXCLUDE_FILE+=("architecture.md")
+EXCLUDE_FILE+=("build.sh")
+EXCLUDE_FILE+=("codeception.yml")
+EXCLUDE_FILE+=("composer.lock")
+
+# Directories not needed in the release package.
+EXCLUDE_DIR=("docs")
+EXCLUDE_DIR+=("examples")
+EXCLUDE_DIR+=("Examples")
+EXCLUDE_DIR+=("tests")
+EXCLUDE_DIR+=("Tests")
+EXCLUDE_DIR+=("unitTests")
+
+# As always, there are some exceptions :-)
+KEEP=("lib/Twig/Node/Expression/Test")
+
+KEEP_FLAGS=()
+for E in "${KEEP[@]}"; do
+  KEEP_FLAGS+=("!")
+  KEEP_FLAGS+=("-path")
+  KEEP_FLAGS+=("\*${E}\*")
+done
+
+
+# Create copies of all the stuff.
+# Try to copy not much more than what's needed.
+
+# Git repositories.
+export D
+for D in "${REPOS_GIT[@]}"; do
+  (
+    echo -n "Copying ${D} ... "
+    cd ${D} || continue
+
+    mkdir -p "${DIR}/${D}"
+    git archive master | tar -C "${DIR}/${D}" -xf-
+
+    cd "${DIR}/${D}"
+    if [ -d admin-dev ]; then
+      mv admin-dev admin
+    fi
+    if [ -d install-dev ]; then
+      mv install-dev install
+    fi
+
+    echo "done."
+  )
+done
+
+# Composer repositories. Not reasonably doable without network access,
+# but fortunately composer maintains a cache, so no heavy downloads.
+(
+  cd "${DIR}" || exit 1
+  composer install --no-dev
+  composer dump-autoload -o
+)
+
+
+# Cleaning :-)
+(
+  cd "${DIR}"
+  for E in "${EXCLUDE_FILE[@]}"; do
+    find . "${KEEP_FLAGS[@]}" -type f -name "${E}" -delete
+  done
+  for E in "${EXCLUDE_DIR[@]}"; do
+    find . "${KEEP_FLAGS[@]}" -type d -name "${E}" | while read D; do
+      rm -rf "${D}"
+    done
+  done
+)
+
+
+# Make the package.
+(
+  echo -n "Creating package ... "
+  cd "${DIR}"
+  node ./tools/generatemd5list.js
+  cd ..
+  zip -r -q $(basename "${DIR}").zip $(basename "${DIR}")
+  echo "done."
+)
+
+mv "${DIR}"/../$(basename "${DIR}").zip .
+echo "Created $(basename "${DIR}").zip successfully."
 
 exit 0


### PR DESCRIPTION
Having a package build script which does self-destruction of the Git repository is a really bad idea. Imagine what happens if a developer simply tries ...

This one works without destroying the original repository and can be invoked right from the development repo. It also makes the resulting package about 3 MB smaller due to better cleaning of vendor dependencies.

Using it is trivial: run ```./build.sh``` in the development repository, wait a minute and enjoy the readily built package.