### PR TITLE
Misc

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1624,17 +1624,6 @@ class ToolsCore
     }
 
     /**
-     * Truncate strings
-     *
-     * @param string $str
-     * @param int    $max_length Max length
-     * @param string $suffix     Suffix optional
-     *
-     * @return string $str truncated
-     */
-    /* CAUTION : Use it only on module hookEvents.
-    ** For other purposes use the smarty function instead */
-    /**
      * getHttpHost return the <b>current</b> host used, with the protocol (http or https) if $http is true
      * This function should not be used to choose http or https domain name.
      * Use Tools::getShopDomain() or Tools::getShopDomainSsl instead

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -38,7 +38,6 @@ use vierbergenlars\SemVer\version as Version;
  */
 abstract class ModuleCore
 {
-    const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
     const CACHE_FILE_TAB_MODULES_LIST = '/config/xml/tab_modules_list.xml';
     // @codingStandardsIgnoreStart
     /** @var array used by AdminTab to determine which lang file to use (admin.php or module lang file) */

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -385,7 +385,6 @@ class ShopCore extends ObjectModel
 
     /**
      * Find the shop from current domain / uri and get an instance of this shop
-     * if INSTALL_VERSION is defined, will return an empty shop object
      *
      * @return Shop
      *


### PR DESCRIPTION
Three commits of lower importance, still too valuable to throw them away.

- _Remove constant Module::CACHE_FILE_MODULES_LIST_: last usage of this constant was removed yesterday, and it was dead code.
- _Remove unrelated comments_: apparently forgotten earlier, ```INSTALL_VERSION``` isn't used at all.
- _Be ignorant about submodules_: this commit actually changes something. To me it looks like thirty bees' development model doesn't match Git's default development model too well. Thirty bees apparently develops modules (and the theme) entirely separately and doesn't track changes there with the main repo. Accordingly, the main repo should ignore changes in submodules. Without this, Git laments about submodule changes all the time and a developer has to take care to not pick up such changes in unrelated commits by accident.