### PR TITLE
Installer error reporting

### DIFF
--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -38,7 +38,6 @@ function start_install()
 	is_installing = true;
 
 	$('.process_step').removeClass('fail').removeClass('success').hide();
-	$('.error_log').hide();
 	$('#progress_bar').show();
 	$('#progress_bar .installing').show();
 	$('.stepList li:last-child').removeClass('ok').removeClass('ko');
@@ -186,7 +185,7 @@ function install_error(step, errors)
 			display += '<li>' + v + '</li>';
 		});
 		display += '</ol>';
-		$('#process_step_'+step.key+' .error_log').html(display).show();
+		$('#error_process .error_log').html(display).show();
 	}
 	if (typeof psuser_assistance != 'undefined')
 		psuser_assistance.setStep('install_process_error');

--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -91,12 +91,14 @@ function process_install(step)
 			// An error occured during this step
 			else
 			{
-				install_error(step, (json) ? json.message : '');
+				install_error(step, 'Process '+step.key+'=true: '+(json) ? json.message : '(no message)');
 			}
 		},
-		// An error HTTP (page not found, json not valid, etc.) occured during this step
-		error: function() {
-			install_error(step);
+    error: function(jqXHR, textStatus, errorThrown) {
+      install_error(step, [
+        'Ajax request failed for process '+step.key+'=true with '+textStatus+'.',
+        errorThrown
+      ]);
 		}
 	});
 }
@@ -144,13 +146,15 @@ function process_install_subtask(step, current_subtask)
 				else
 					process_install_subtask(step, current_subtask);
 			}
-			else 
-				install_error(step, (json) ? json.message : '');
+			else
+				install_error(step, 'Subtask '+params+': '+(json) ? json.message : '(no message)');
 		},
-		// An error HTTP (page not found, json not valid, etc.) occured during this step
-		error: function() {
-			install_error(step);
-		}
+    error: function(jqXHR, textStatus, errorThrown) {
+      install_error(step, [
+        'Ajax request failed for subtask '+params+' with '+textStatus+'.',
+        errorThrown
+      ]);
+		},
 	});
 }
 

--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -173,8 +173,6 @@ function install_error(step, errors)
 			list_errors = [];
 			list_errors[0] = errors;
 		}
-		else if ($.type(list_errors) == 'array')
-			list_errors = list_errors[0];
 
 		var display = '<ol>';
 

--- a/install-dev/theme/view.css
+++ b/install-dev/theme/view.css
@@ -762,7 +762,6 @@ ul#optional_update li.ok {
 #progress_bar ol.process_list li.success {
 	background: url("img/bg-li-tabs-finished.png") no-repeat scroll 0 3px transparent;
 	color: #666;
-    text-decoration: line-through;
 	padding-left: 18px;
 }
 #progress_bar ol.process_list li.fail {

--- a/install-dev/theme/view.css
+++ b/install-dev/theme/view.css
@@ -770,19 +770,8 @@ ul#optional_update li.ok {
 	color: red;
 	padding-left: 18px;
 }
-#progress_bar ol.process_list li .error_log {
-	background-color: #FBE8D6;
-	border: 1px solid #666666;
-	color: #000000;
-	max-height: 300px;
-	overflow: auto;
-	padding: 7px;
-}
-#progress_bar ol.process_list li .error_log ol {
-	list-style-type: decimal;
-}
-#progress_bar ol.process_list li .error_log li {
-	padding: 3px;
+#progress_bar .error_log ol {
+	margin-top: 0;
 }
 
 #error_process{

--- a/install-dev/theme/views/process.phtml
+++ b/install-dev/theme/views/process.phtml
@@ -24,7 +24,6 @@ var admin = '<?php echo(file_exists('../admin-dev') ? '../admin-dev' : '../admin
 			<?php foreach ($this->processSteps as $item): ?>
 				<li id="process_step_<?php echo $item['key'] ?>" class="process_step">
 					<?php echo $item['lang'] ?>
-					<div class="error_log"></div>
 				</li>
 			<?php endforeach; ?>
 		</ol>
@@ -32,6 +31,7 @@ var admin = '<?php echo(file_exists('../admin-dev') ? '../admin-dev' : '../admin
 		<div id="error_process">
 			<h3><?php echo $this->l('An error occurred during installation...') ?></h3>
 			<p><?php echo $this->l('You can use the links on the left column to go back to the previous steps, or restart the installation process by <a href="%s">clicking here</a>.', 'index.php?restart=true') ?></p>
+			<div class="error_log"></div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Again cases of too much code :-)

Without this, installation errors generate a generic error message, only. Messages are available, so let's display them! Most of the code was already there, it just had to be kind of enabled.

No change for successful installations, except step descriptions now shown in normal text instead of strikethrough.