### PR TITLE
Fix notices (see below) when no currency rate modules are installed.

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -251,6 +251,10 @@ class CurrencyCore extends ObjectModel
         }
 
         $currencyRates = CurrencyRateModule::getCurrencyRateInfo();
+        if ($currencyRates === false) {
+            return null;
+        }
+        $currencyRates = array_filter($currencyRates);
         $moduleRates = [];
         foreach ($currencyRates as $currency => $module) {
             if (Tools::strtoupper($currency) === Tools::strtoupper($defaultCurrency->iso_code)) {


### PR DESCRIPTION
```
[Fri Apr 28 17:17:36.506491 2017] [:error] [pid 13095] [client 192.168.1.11:51756] PHP Notice:  Trying to get property of non-object in /home/sites/test/ThirtyBees/classes/Currency.php on line 259, referer: http://test.skoro.si/ThirtyBees/admin-dev/index.php?controller=AdminLocalization&token=4c518918e8ab010911a83a9968c1b829
[Fri Apr 28 17:17:36.506613 2017] [:error] [pid 13095] [client 192.168.1.11:51756] PHP Notice:  Trying to get property of non-object in /home/sites/test/ThirtyBees/classes/Currency.php on line 260, referer: http://test.skoro.si/ThirtyBees/admin-dev/index.php?controller=AdminLocalization&token=4c518918e8ab010911a83a9968c1b829
```