### PR TITLE
Allow '*automatic*' PS_SHOP_DOMAIN.

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -435,6 +435,14 @@ class ConfigurationCore extends ObjectModel
                 static::$_cache[static::$definition['table']][$lang]['global'][$row['name']] = $row['value'];
             }
         }
+
+        // Adjust automatic values.
+        if (static::get('PS_SHOP_DOMAIN') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN', $_SERVER['HTTP_HOST']);
+        }
+        if (static::get('PS_SHOP_DOMAIN_SSL') === '*automatic*') {
+            static::set('PS_SHOP_DOMAIN_SSL', $_SERVER['HTTP_HOST']);
+        }
     }
 
     /**
@@ -673,6 +681,14 @@ class ConfigurationCore extends ObjectModel
                     );
                 }
             }
+        }
+
+        // Adjust automatic values.
+        if ($key === 'PS_SHOP_DOMAIN' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
+        }
+        if ($key === 'PS_SHOP_DOMAIN_SSL' && in_array('*automatic*', $values)) {
+            $values = $_SERVER['HTTP_HOST'];
         }
 
         Configuration::set($key, $values, $idShopGroup, $idShop);

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -250,8 +250,16 @@ class ShopCore extends ObjectModel
         $this->theme_directory = $row['directory'];
         $this->physical_uri = $row['physical_uri'];
         $this->virtual_uri = $row['virtual_uri'];
-        $this->domain = $row['domain'];
-        $this->domain_ssl = $row['domain_ssl'];
+        if ($row['domain'] === '*automatic*') {
+            $this->domain = $_SERVER['HTTP_HOST'];
+        } else {
+            $this->domain = $row['domain'];
+        }
+        if ($row['domain_ssl'] === '*automatic*') {
+            $this->domain_ssl = $_SERVER['HTTP_HOST'];
+        } else {
+            $this->domain_ssl = $row['domain'];
+        }
 
         return true;
     }
@@ -471,6 +479,30 @@ class ShopCore extends ObjectModel
                 }
             }
         } else {
+            // Handle automatic shop URLs.
+            if (!$idShop) {
+                // The whole purpose of this block is to find out wether
+                // we should load the default shop with or without redirection.
+                // Keeping $idShop at false means with redirection.
+                $idDefaultShop = Configuration::get('PS_SHOP_DEFAULT');
+
+                // Get this directly from the database to see '*automatic*'.
+                $sql = 'SELECT domain, domain_ssl
+                        FROM '._DB_PREFIX_.'shop_url
+                        WHERE id_shop = \''.pSQL($idDefaultShop).'\'';
+                $result = Db::getInstance()->executeS($sql);
+
+                if (Configuration::get('PS_SSL_ENABLED')) {
+                    if ($result[0]['domain_ssl'] === '*automatic*') {
+                        $idShop = $idDefaultShop;
+                    }
+                } else {
+                    if ($result[0]['domain'] === '*automatic*') {
+                        $idShop = $idDefaultShop;
+                    }
+                }
+            }
+
             $shop = new Shop($idShop);
             if (!Validate::isLoadedObject($shop) || !$shop->active) {
                 // No shop found ... too bad, let's redirect to default shop

--- a/classes/shop/ShopUrl.php
+++ b/classes/shop/ShopUrl.php
@@ -228,8 +228,18 @@ class ShopUrlCore extends ObjectModel
 			WHERE main = 1
 			AND id_shop = '.($idShop !== null ? (int) $idShop : (int) Context::getContext()->shop->id)
             );
-            static::$main_domain[(int) $idShop] = $row['domain'];
-            static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+
+            // Adjust automatic values.
+            if ($row['domain'] === '*automatic*') {
+                static::$main_domain[(int) $idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain[(int) $idShop] = $row['domain'];
+            }
+            if ($row['domain_ssl'] === '*automatic*') {
+                static::$main_domain_ssl[(int) $idShop] = $_SERVER['HTTP_HOST'];
+            } else {
+                static::$main_domain_ssl[(int) $idShop] = $row['domain_ssl'];
+            }
         }
     }
 

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -158,7 +158,7 @@ class AdminMetaControllerCore extends AdminController
         if (!Shop::isFeatureActive()) {
             $this->url = ShopUrl::getShopUrls($this->context->shop->id)->where('main', '=', 1)->getFirst();
             if ($this->url) {
-                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. If you migrate your shop to a new URL, remember to change the values below.');
+                $shopUrlOptions['description'] = $this->l('Here you can set the URL for your shop. You can set this to literally \'*automatic*\' (with stars, without quotes) to let thirty bees detect this automatically. If you migrate your shop to a new URL and don\'t use \'*automatic*\', remember to change the values below.');
                 $shopUrlOptions['fields'] = [
                     'domain'     => [
                         'title'        => $this->l('Shop domain'),


### PR DESCRIPTION
Let's start with something simple. Will post an RFC in the forum in a minute.

In PS 1.7 this feature worked mostly, too. Except for uploading product images (something like 'image not found', IIRC). Can't reproduce this in 30bz, product images upload and get used just fine.

Commit message:

One of the obstacles against automatic shop synchonisation is the
shop's domain name stored in the database. After copying a shop
from here to there one has to adjust these two values manually
from the admin panel, which defeats the 'automatic' part and
costs additional downtime.

Because there might be use-cases for this storage even in monoshop
mode, this storage wasn't removed. Instead, a keyword '*automatic*'
was made valid which causes ignorance of these stored values. This
way one gets the best of both, allowing an arbitrary shop domain
for those who want it and insistence on the stored value for those
who need it.

This feature works even in multishop mode. It makes sense to set
the default shop to *automatic*, then all unknown domains will
load that default shop without redirection. Known domains load
their related shop.