### PR TITLE
Fix CSV tag import

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
@@ -202,13 +202,13 @@
 						<label for="separator" class="control-label col-lg-4">{l s='Field separator'}</label>
 						<div class="col-lg-8">
 							<input id="separator" name="separator" class="fixed-width-xs form-control" type="text" value="{if isset($separator_selected)}{$separator_selected|escape:'html':'UTF-8'}{else};{/if}" />
-							<div class="help-block">{l s='e.g. '} 1; Blouse; 129.90; 5</div>
+							<div class="help-block">{l s='e.g. '} 1, Blouse, 129.90, 5</div>
 						</div>
 						<div class="form-group">
 							<label for="multiple_value_separator" class="control-label col-lg-4">{l s='Multiple value separator'}</label>
 							<div class="col-lg-8">
 								<input id="multiple_value_separator" name="multiple_value_separator" class="fixed-width-xs form-control" type="text" value="{if isset($multiple_value_separator_selected)}{$multiple_value_separator_selected|escape:'html':'UTF-8'}{else},{/if}" />
-								<div class="help-block">{l s='e.g. '} Blouse; red.jpg, blue.jpg, green.jpg; 129.90</div>
+								<div class="help-block">{l s='e.g. '} red.jpg; blue.jpg; green.jpg</div>
 							</div>
 						</div>
 					</div>

--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -99,7 +99,8 @@ class TagCore extends ObjectModel
      * @param int          $idLang    Language id
      * @param int          $idProduct Product id to link tags with
      * @param string|array $tagList   List of tags, as array or as a string with comas
-     * @param string       $separator
+     * @param string       $separator Separator to split a given string inot an array.
+     *                                Not needed if $tagList is an array already.
      *
      * @return bool Operation success
      *
@@ -113,7 +114,7 @@ class TagCore extends ObjectModel
         }
 
         if (!is_array($tagList)) {
-            $tagList = array_filter(array_unique(array_map('trim', preg_split('#\\'.$separator.'#', $tagList, null, PREG_SPLIT_NO_EMPTY))));
+            $tagList = explode($separator, $tagList);
         }
 
         $list = [];

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2710,13 +2710,9 @@ class AdminImportControllerCore extends AdminController
                 // Delete tags for this id product, for no duplicating error
                 Tag::deleteTagsForProduct($product->id);
                 if (!is_array($product->tags) && !empty($product->tags)) {
-                    $product->tags = static::createMultiLangField($product->tags);
-                    foreach ($product->tags as $key => $tags) {
-                        $isTagAdded = Tag::addTags($key, $product->id, $tags, $this->multiple_value_separator);
-                        if (!$isTagAdded) {
-                            $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Tags list is invalid'));
-                            break;
-                        }
+                    $isTagAdded = Tag::addTags($idLang, $product->id, $product->tags, $this->multiple_value_separator);
+                    if (!$isTagAdded) {
+                        $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Tags list is invalid'));
                     }
                 } else {
                     foreach ($product->tags as $key => $tags) {
@@ -4472,7 +4468,7 @@ class AdminImportControllerCore extends AdminController
             );
         }
         $this->closeCsvFile($handle);
-        
+
         return $lineCount;
     }
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2694,7 +2694,7 @@ class AdminImportControllerCore extends AdminController
                     $tags = Tag::getProductTags($product->id);
                     if (is_array($tags) && count($tags)) {
                         if (!empty($product->tags)) {
-                            $product->tags = explode($this->multiple_value_separator, $product->tags);
+                            $product->tags = $this->fieldExplode($product->tags);
                         }
                         if (is_array($product->tags) && count($product->tags)) {
                             foreach ($product->tags as $key => $tag) {
@@ -2709,8 +2709,8 @@ class AdminImportControllerCore extends AdminController
                 }
                 // Delete tags for this id product, for no duplicating error
                 Tag::deleteTagsForProduct($product->id);
-                if (!is_array($product->tags) && !empty($product->tags)) {
-                    $isTagAdded = Tag::addTags($idLang, $product->id, $product->tags, $this->multiple_value_separator);
+                if (!is_array($product->tags)) {
+                    $isTagAdded = Tag::addTags($idLang, $product->id, $this->fieldExplode($product->tags));
                     if (!$isTagAdded) {
                         $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Tags list is invalid'));
                     }
@@ -5175,4 +5175,32 @@ class AdminImportControllerCore extends AdminController
             );
         }
     }
+
+    /**
+     * Explode a field by multi-value separators. This is a bit more tricky
+     * than a simple explode(), see https://www.ietf.org/rfc/rfc4180.txt and
+     * https://en.wikipedia.org/wiki/Comma-separated_values.
+     *
+     * @param string $field Field to explode.
+     *
+     * @return array Array with single values as strings.
+     *
+     * @TODO While this is usable for seperating other fields than tags, escape
+     *       sequences are ignored so far.
+     *
+     * @since 1.0.2
+     */
+    protected function fieldExplode($field)
+    {
+        if (!is_string($field)) {
+            return [];
+        }
+
+        $field = trim($field, '"');
+        $field = str_replace([$this->separator, $this->multiple_value_separator],
+                             $this->separator, $field);
+
+        return explode($this->separator, $field);
+    }
+
 }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2716,23 +2716,16 @@ class AdminImportControllerCore extends AdminController
                     }
                 } else {
                     foreach ($product->tags as $key => $tags) {
-                        $str = '';
-                        foreach ($tags as $oneTag) {
-                            $str .= $oneTag.$this->multiple_value_separator;
-                        }
-                        $str = rtrim($str, $this->multiple_value_separator);
-
-                        $isTagAdded = Tag::addTags($key, $product->id, $str, $this->multiple_value_separator);
+                        $isTagAdded = Tag::addTags($key, $product->id, $tags);
                         if (!$isTagAdded) {
                             $this->addProductWarning(
                                 Tools::safeOutput($info['name']),
                                 (int) $product->id,
                                 sprintf(
                                     $this->l('Invalid tag(s) (%s)'),
-                                    $str
+                                    implode(', ', $tags)
                                 )
                             );
-                            break;
                         }
                     }
                 }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -565,9 +565,9 @@ class AdminImportControllerCore extends AdminController
             }
         }
 
-        $this->separator = ($separator = Tools::substr(strval(trim(Tools::getValue('separator'))), 0, 1)) ? $separator : ';';
+        $this->separator = ($separator = Tools::substr(strval(trim(Tools::getValue('separator'))), 0, 1)) ? $separator : ',';
         $this->convert = false;
-        $this->multiple_value_separator = ($separator = Tools::substr(strval(trim(Tools::getValue('multiple_value_separator'))), 0, 1)) ? $separator : ',';
+        $this->multiple_value_separator = ($separator = Tools::substr(strval(trim(Tools::getValue('multiple_value_separator'))), 0, 1)) ? $separator : ';';
     }
 
     /**


### PR DESCRIPTION
This replaces issue #285. It just occured to me that one can make a PR from within the repo, too, and that this is probably better for review.

1. CSV import: don't make tags multi-language.
   CSV imports are declared as an import for one language, so import that. Before, importing tags for another language would overwrite previously imported tags.
2. CSV import: align default field separators with RFC 4180.
   This is, comma (',') as standard field separator.
   Definition of multiple values inside fields isn't standardized.
   Some applications use a semicolon (';'), others a quoted string with commas inside. See https://www.ietf.org/rfc/rfc4180.txt
3. CSV import: separate tags according to RFC 4180.
   This is done by introducing a separation function, so it can get applied to other areas as well.
4. CSV import: simplify adding an array of tags.
   There is no point in assembling a string, Tags::addTags happily accepts an array directly.
   Also don't break if one language fails, the other ones may succeed.
5. TagsCore: simplify splitting a provided string.
   There is no point in filtering, validation happens anyways.

While all of them target CSV imports, I hope they don't break other imports.
