### PR TITLE
Installreports

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -415,15 +415,22 @@ class ConfigurationTestCore
         }
 
         if ($recursive) {
-            foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($absoluteDir)) as $file) {
-                /** @var SplFileInfo $file */
-                if (in_array($file->getFilename(), ['.', '..']) || $file->isLink()) {
+            foreach (scandir($absoluteDir, SCANDIR_SORT_NONE) as $item) {
+                $path = $absoluteDir.DIRECTORY_SEPARATOR.$item;
+
+                if (in_array($item, ['.', '..'])
+                    || is_link($path)) {
                     continue;
                 }
 
-                if (!is_writable($file)) {
-                    $fullReport = sprintf('File %s is not writable.', $file);
+                if (is_dir($path)) {
+                    if (!ConfigurationTest::testDir($path, $recursive, $fullReport, true)) {
+                        return false;
+                    }
+                }
 
+                if (!is_writable($path)) {
+                    $fullReport = sprintf('File %s is not writable.', $path);
                     return false;
                 }
             }

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -437,12 +437,18 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testSitemap($dir)
+    public static function testSitemap($dir, &$report = null)
     {
-        return ConfigurationTest::testFile($dir);
+        if (!ConfigurationTest::testFile($dir)) {
+            $report = 'File or directory '.$dir.' is not writable.';
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -450,14 +456,25 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testFile($fileRelative)
+    public static function testFile($fileRelative, &$report = null)
     {
         $file = _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.$fileRelative;
 
-        return (file_exists($file) && is_writable($file));
+        if (!file_exists($file)) {
+            $report = 'File or directory '.$file.' does not exist.';
+            return false;
+        }
+
+        if (!is_writable($file)) {
+            $report = 'File or directory '.$file.' is not writable.';
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -750,6 +767,9 @@ class ConfigurationTestCore
     }
 
     /**
+     * Test the set of files defined above. Not used by the installer, but by
+     * AdminInformationController.
+     *
      * @param bool $full
      *
      * @return array|bool

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -150,7 +150,7 @@ class ConfigurationTestCore
      * @param string $ptr
      * @param int    $arg
      *
-     * @return string
+     * @return string 'ok' on success, 'fail' on failure.
      *
      * @since   1.0.0
      * @version 1.0.0 Initial version
@@ -394,7 +394,7 @@ class ConfigurationTestCore
         }
 
         if (!file_exists($absoluteDir)) {
-            $fullReport = sprintf('Directory %s does not exist or is not writable', $absoluteDir);
+            $fullReport = sprintf('Directory %s does not exist', $absoluteDir);
 
             return false;
         }

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -418,7 +418,7 @@ class ConfigurationTestCore
             foreach (scandir($absoluteDir, SCANDIR_SORT_NONE) as $item) {
                 $path = $absoluteDir.DIRECTORY_SEPARATOR.$item;
 
-                if (in_array($item, ['.', '..'])
+                if (in_array($item, ['.', '..', '.git'])
                     || is_link($path)) {
                     continue;
                 }

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -314,13 +314,15 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testSystem($funcs)
+    public static function testSystem($funcs, &$report = null)
     {
         foreach ($funcs as $func) {
             if (!function_exists($func)) {
+                $report = 'Function '.$func.'() does not exist.';
                 return false;
             }
         }

--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -150,18 +150,24 @@ class ConfigurationTestCore
      * @param string $ptr
      * @param int    $arg
      *
-     * @return string 'ok' on success, 'fail' on failure.
+     * @return string 'ok' on success, 'fail' or error message on failure.
      *
+     * @since   1.0.2 Also report error message.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
     public static function run($ptr, $arg = 0)
     {
-        if (call_user_func(['ConfigurationTest', 'test'.$ptr], $arg)) {
-            return 'ok';
+        $report = '';
+        $result = call_user_func_array(['ConfigurationTest', 'test'.$ptr], [$arg, &$report]);
+
+        if (strlen($report)) {
+            return $report;
+        } elseif (!$result) {
+            return 'fail';
         }
 
-        return 'fail';
+        return 'ok';
     }
 
     /**
@@ -364,12 +370,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testConfigDir($dir)
+    public static function testConfigDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -394,13 +401,13 @@ class ConfigurationTestCore
         }
 
         if (!file_exists($absoluteDir)) {
-            $fullReport = sprintf('Directory %s does not exist', $absoluteDir);
+            $fullReport = sprintf('Directory %s does not exist.', $absoluteDir);
 
             return false;
         }
 
         if (!is_writable($absoluteDir)) {
-            $fullReport = sprintf('Directory %s is not writable', $absoluteDir);
+            $fullReport = sprintf('Directory %s is not writable.', $absoluteDir);
 
             return false;
         }
@@ -413,7 +420,7 @@ class ConfigurationTestCore
                 }
 
                 if (!is_writable($file)) {
-                    $fullReport = sprintf('File %s is not writable', $file);
+                    $fullReport = sprintf('File %s is not writable.', $file);
 
                     return false;
                 }
@@ -456,12 +463,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testRootDir($dir)
+    public static function testRootDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -469,12 +477,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testLogDir($dir)
+    public static function testLogDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -482,12 +491,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testAdminDir($dir)
+    public static function testAdminDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -495,12 +505,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testImgDir($dir)
+    public static function testImgDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -508,12 +519,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testModuleDir($dir)
+    public static function testModuleDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -521,12 +533,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testCacheDir($dir)
+    public static function testCacheDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -534,12 +547,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testToolsV2Dir($dir)
+    public static function testToolsV2Dir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -547,12 +561,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testCacheV2Dir($dir)
+    public static function testCacheV2Dir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -560,12 +575,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testDownloadDir($dir)
+    public static function testDownloadDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -573,12 +589,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testMailsDir($dir)
+    public static function testMailsDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -586,12 +603,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testTranslationsDir($dir)
+    public static function testTranslationsDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -599,17 +617,18 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testThemeLangDir($dir)
+    public static function testThemeLangDir($dir, &$report = null)
     {
         $absoluteDir = rtrim(_PS_ROOT_DIR_, '\\/').DIRECTORY_SEPARATOR.trim($dir, '\\/');
         if (!file_exists($absoluteDir)) {
             return false;
         }
 
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -617,17 +636,18 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testThemePdfLangDir($dir)
+    public static function testThemePdfLangDir($dir, &$report = null)
     {
         $absoluteDir = rtrim(_PS_ROOT_DIR_, '\\/').DIRECTORY_SEPARATOR.trim($dir, '\\/');
         if (!file_exists($absoluteDir)) {
             return true;
         }
 
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -635,17 +655,18 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testThemeCacheDir($dir)
+    public static function testThemeCacheDir($dir, &$report = null)
     {
         $absoluteDir = rtrim(_PS_ROOT_DIR_, '\\/').DIRECTORY_SEPARATOR.trim($dir, '\\/');
         if (!file_exists($absoluteDir)) {
             return true;
         }
 
-        return ConfigurationTest::testDir($dir, true);
+        return ConfigurationTest::testDir($dir, true, $report);
     }
 
     /**
@@ -653,12 +674,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testCustomizableProductsDir($dir)
+    public static function testCustomizableProductsDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**
@@ -666,12 +688,13 @@ class ConfigurationTestCore
      *
      * @return bool
      *
+     * @since   1.0.2 Add $report.
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function testVirtualProductsDir($dir)
+    public static function testVirtualProductsDir($dir, &$report = null)
     {
-        return ConfigurationTest::testDir($dir);
+        return ConfigurationTest::testDir($dir, false, $report);
     }
 
     /**

--- a/install-dev/controllers/http/system.php
+++ b/install-dev/controllers/http/system.php
@@ -148,8 +148,10 @@ class InstallControllerHttpSystem extends InstallControllerHttp
 
         foreach ($this->testsRender['required'] as &$category) {
             foreach ($category['checks'] as $id => $check) {
-                if ($this->tests['required']['checks'][$id] != 'ok') {
+                $result = $this->tests['required']['checks'][$id];
+                if ($result != 'ok') {
                     $category['success'] = 0;
+                    $category['checks'][$id] .= ': '.$result;
                 }
             }
         }

--- a/install-dev/theme/view.css
+++ b/install-dev/theme/view.css
@@ -629,11 +629,6 @@ ul#optional li {
 	border-bottom: 1px solid #ccc;
 }
 
-ul#required li.ok,
-ul#optional li.ok {
-	display: none
-}
-
 ul#required li.fail,
 ul#optional li.fail {
 	background: #f8eba8 url(img/pict_error.png) no-repeat 99% 8px;

--- a/install-dev/theme/views/system.phtml
+++ b/install-dev/theme/views/system.phtml
@@ -16,12 +16,14 @@ $this->displayTemplate('header')
 <?php foreach ($this->testsRender as $type => $categories): ?>
 	<ul id="<?php echo $type ?>">
 	<?php foreach ($categories as $category): ?>
-		<li class="title <?php if ($category['success'] == 1): ?>ok<?php endif;?>"><?php echo $category['title'] ?></li>
-		<?php $i = 0; foreach ($category['checks'] as $id => $lang): ?>
-			<li class="required <?php if ($i == 0): ?>first<?php endif;?> <?php echo $this->tests[$type]['checks'][$id] ?>">
-				<?php echo $lang ?>
-			</li>
-		<?php $i++; endforeach; ?>
+        <?php if ($category['success'] == 0) { ?>
+            <li class="title"><?php echo $category['title'] ?></li>
+            <?php foreach ($category['checks'] as $id => $lang) { ?>
+                <?php if ($this->tests[$type]['checks'][$id] != 'ok') { ?>
+                    <li class="required fail"><?php echo $lang ?></li>
+                <?php } ?>
+            <?php } ?>
+        <?php } ?>
 	<?php endforeach; ?>
 	</ul>
 <?php endforeach; ?>


### PR DESCRIPTION
Today I had enough of these vague "directory not recursive writable" messages at installation time, so I digged into this.

- Error messages created during these tests get now forwarded to the installer screen. With this, finding the culprit was easy: a file inside a `.git` folder.
- Also rewrote this recursive test, it now tests directories, too. RecursiveDirectoryIterator lists only plain files.
- And excluded `.git` directories, of course.

Not pushed to *1.0.x* directly, because I'm not sure whether it's a good idea to do changes in such a sensible area shortly before a release.