### PR TITLE
Fix DB::getInstance()->NumRows() deprecated or not working anymore

### DIFF
--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -292,7 +292,7 @@ class PrestaShopBackupCore
 
             if (!in_array($schema[0]['Table'], $ignoreInsertTable)) {
                 $data = Db::getInstance()->query('SELECT * FROM `'.$schema[0]['Table'].'`');
-                $sizeof = DB::getInstance()->NumRows();
+                $sizeof = Db::getInstance()->query('SELECT COUNT(*) FROM `'.$schema[0]['Table'].'`');
                 $lines = explode("\n", $schema[0]['Create Table']);
 
                 if ($data && $sizeof > 0) {


### PR DESCRIPTION
the Backup system created archives files but empty of datas, only tables structure were saved.

http://doc.prestashop.com/display/PS15/DB+class+best+practices#DBclassbestpractices-NumRows()

says it's deprecated.. and the fact is that it was not working anymore.. it returned NULL, so the test after was failed and no data was sent.. Backup were only including structure no datas, and now it's fixed !