### PR TITLE
Tax on invoice is broken

### DIFF
--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -545,7 +545,7 @@ class OrderInvoiceCore extends ObjectModel
         }
 
         foreach ($details as $row) {
-            $rate = (float) round($row['tax_rate'], 3);
+            $rate = sprintf('%.3f', $row['tax_rate']);
             if (!isset($breakdown[$rate])) {
                 $breakdown[$rate] = [
                     'total_price_tax_excl' => 0,


### PR DESCRIPTION
I readded the old value from PS. The new line from thirtybees breaks the taxe rates on pdf invoice. Instead of 2.500% it just shows 2%...
No idea why, but on my template it acts like this...
Not even $rate = $row['tax_rate']; is working 