### PR TITLE
Validate::isDate(): allow all zero dates.

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -693,7 +693,12 @@ class ValidateCore
             return false;
         }
 
-        return checkdate((int) $matches[2], (int) $matches[3], (int) $matches[1]);
+        foreach ([1, 2, 3] as $i) {
+            $matches[$i] = (int) $matches[$i];
+        }
+
+        return ($matches[1] === 0 && $matches[2] === 0 && $matches[3] === 0)
+               || checkdate($matches[2], $matches[3], $matches[1]);
     }
 
     /**


### PR DESCRIPTION
Yesterday I tripped across the fact that trying to insert an empty string as date works perfectly fine, but updating such a record without changing that date does not work.

Regarding an empty string: such dates aren't validated at all, see https://github.com/thirtybees/thirtybees/blob/datevalidation/classes/ObjectModel.php#L1170

All zero dates didn't validate because [PHP checkdate()](http://php.net/manual/en/function.checkdate.php) asks for a minimum date of 0001-01-01.

Thirty bees uses the SQL 'DATETIME' type to store dates in the database. While this type limits valid dates to the range 1000-01-01 00:00:00 to 9999-12-31 23:59:59, 0000-00-00 00:00:00 is the choosen 'zero' date for this field type and accordingly, an insertable date value. Accordingly, Validate::isDate('0000-00-00 00:00:00') should succeed.

Usages of all zero dates include all non-required dates, e.g. the expiration date of a virtual product download. So far, all this code resetted all-zero dates to an empty string or did ugly hacks like this: https://github.com/thirtybees/thirtybees/blob/datevalidation/controllers/admin/AdminProductsController.php#L2207

References:

https://dev.mysql.com/doc/refman/5.5/en/datetime.html
https://dev.mysql.com/doc/refman/8.0/en/datetime.html
http://php.net/manual/en/function.checkdate.php