### PR TITLE
Resolves Bug for filtering "name" column

### DIFF
--- a/controllers/admin/AdminStockManagementController.php
+++ b/controllers/admin/AdminStockManagementController.php
@@ -66,7 +66,7 @@ class AdminStockManagementControllerCore extends AdminController
             ],
             'name'              => [
                 'title'      => $this->l('Name'),
-                'filter_key' => 'pl!name',
+                'filter_key' => 'b!name',
             ],
             'physical_quantity' => [
                 'title'   => $this->l('Physical quantity'),


### PR DESCRIPTION
The column name has a Join as 'b' not 'pl'. That's why there is an error when trying to filter the column.