### PR TITLE
Fix last_activity timeout

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3839,7 +3839,7 @@ class AdminControllerCore extends Controller
         }
 
         if (isset(Context::getContext()->cookie->last_activity)) {
-            if ($this->context->cookie->last_activity + 900 < time()) {
+            if ($this->context->cookie->last_activity + $cookie_lifetime < time()) {
                 $this->context->employee->logout();
             } else {
                 $this->context->cookie->last_activity = time();


### PR DESCRIPTION
Removed the hardcoded 900 sec and changed it to use $cookie_lifetime set in BO and calculated in config/config.php

This should fix an old PS issue with people getting logged out after 15 min of inactivity, and make it respect the values set for cookie time set in BO.