### PR TITLE
Duplicating products

### DIFF
--- a/classes/Attachment.php
+++ b/classes/Attachment.php
@@ -183,15 +183,16 @@ class AttachmentCore extends ObjectModel
      */
     public static function getAttachments($idLang, $idProduct, $include = true)
     {
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
-            (new DbQuery())
-                ->select('a.*, al.*')
-                ->from('attachment', 'a')
-                ->leftJoin('attachment_lang', 'al', 'a.`id_attachment` = al.`id_attachment`')
-                ->leftJoin('product_attachment', 'pa', 'pa.`id_attachment` = a.`id_attachment`')
-                ->where('al.`id_lang` = '.(int) $idLang)
-                ->where($include ? 'pa.`id_product` = '.(int) $idProduct : '')
-                ->where('pa.`id_product` IS '.($include ? 'NOT ' : '').'NULL')
+        return Db::getInstance()->executeS('
+            SELECT *
+            FROM '._DB_PREFIX_.'attachment a
+            LEFT JOIN '._DB_PREFIX_.'attachment_lang al
+                ON (a.id_attachment = al.id_attachment AND al.id_lang = '.(int) $idLang.')
+            WHERE a.id_attachment '.($include ? 'IN' : 'NOT IN').' (
+                SELECT pa.id_attachment
+                FROM '._DB_PREFIX_.'product_attachment pa
+                WHERE id_product = '.(int) $idProduct.'
+            )'
         );
     }
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3097,7 +3097,7 @@ class ProductCore extends ObjectModel
      */
     public static function duplicateSpecificPrices($oldProductId, $productId)
     {
-        foreach (SpecificPrice::getIdsByProductId((int) $oldProductId) as $data) {
+        foreach (SpecificPrice::getByProductId((int) $oldProductId) as $data) {
             $specificPrice = new SpecificPrice((int) $data['id_specific_price']);
             if (!$specificPrice->duplicate((int) $productId)) {
                 return false;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -768,6 +768,7 @@ class AdminProductsControllerCore extends AdminController
                 && Product::duplicateCustomizationFields($idProductOld, $product->id)
                 && Product::duplicateTags($idProductOld, $product->id)
                 && Product::duplicateDownload($idProductOld, $product->id)
+                && Product::duplicateAttachments($idProductOld, $product->id)
             ) {
                 if ($product->hasAttributes()) {
                     Product::updateDefaultAttribute($product->id);


### PR DESCRIPTION
I found when duplicating products that Specific Prices were not getting duplicated, even though they were supposed to.  The change to classes/Product.php solves that issue.

I also found that attachments weren't duplicated.  The change to controllers/admin/AdminProductsController.php adds that feature.