### PR TITLE
Fix returning HTML error to AJAX request

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1508,6 +1508,9 @@ class AdminProductsControllerCore extends AdminController
         }
         $res = false;
         if ($json = Tools::getValue('json')) {
+            // If there is an exception, at least the response is in JSON format.
+            $this->json = true;
+
             $res = true;
             $json = stripslashes($json);
             $images = json_decode($json, true);


### PR DESCRIPTION
When reordering images in a product with the multishop active, in some cases there might be exceptions, and this leads to HTML being returned to a AJAX request expecting JSON, with the following:
```
SyntaxError: JSON Parse error: Unrecognized token '<'
```
visible in browser console. With this, the response will always be JSON.