### PR TITLE
XML Output starter changed back to PS

### DIFF
--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -317,9 +317,9 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
     public function overrideContent($content)
     {
         $xml = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
-        $xml .= '<thirtybees xmlns:xlink="http://www.w3.org/1999/xlink">'."\n";
+        $xml .= '<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">'."\n";
         $xml .= $content;
-        $xml .= '</thirtybees>'."\n";
+        $xml .= '</prestashop>'."\n";
 
         return $xml;
     }


### PR DESCRIPTION
Helped out one on the forum today, he had issues with his service provider sendcloud, they use Webservices, and are looking for the prestashop opening tag in XML files - <prestashop xmlns:xlink="http://www.w3.org/1999/xlink">

But failed to import orders since the reply was <thirtybees xmlns:xlink="http://www.w3.org/1999/xlink">

Think it needs to be changed back to prestashop to keep compatibility alive when it comes to webservices.