### PR TITLE
Fix pagination on the customer group list

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -190,6 +190,10 @@ class AdminGroupsControllerCore extends AdminController
             if (isset($_POST['submitReset'.$this->list_id])) {
                 $this->processResetFilters();
             }
+
+            if (Tools::getIsset('submitFilter' . $this->list_id)) {
+                static::$currentIndex .= '&id_group=' . (int)Tools::getValue('id_group') . '&viewgroup';
+            }
         } else {
             $this->list_id = 'group';
         }


### PR DESCRIPTION
When you try to navigate through differents pages of the customer group list, the pagination will redirect you to the groups list instead of the specified page.