### PR TITLE
Support favicon templates

### DIFF
--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -95,11 +95,12 @@
       </div>
     {/if}
   {elseif $field['type'] == 'code'}
-    {if $key === 'TB_SOURCE_FAVICON_CODE'}
+    {if !empty($field['grab_favicon_template'])}
       <script type="text/javascript">
         (function () {
           function resetRefreshButton(target) {
             target.innerHTML = '<i class="icon icon-download"></i> <span>{l s='Download a new template' js=1}</span>';
+            target.disabled = false;
           }
 
           window.downloadNewFaviconTemplate = function (e) {
@@ -112,6 +113,7 @@
             i.className = i.className.replace('icon-download', 'icon-refresh icon-spin');
             var span = target.querySelector('span');
             span.innerHTML = '{l s='Refreshing...' js=1}';
+            target.disabled = true;
 
             var request = new XMLHttpRequest();
             request.open('GET', currentIndex + '&ajax=1&action=refreshFaviconTemplate&controller=AdminThemes&token=' + token, true);
@@ -123,7 +125,7 @@
                   if (!response.hasError) {
                     document.getElementById('{$key|escape:'htmlall':'UTF-8'}').value = atob(response.template);
                     window.aces['{$key|escape:'javascript':'UTF-8'}'].setValue(atob(response.template), -1);
-                    window.showSuccessMessage('{l s='Successfully refreshed the favicon template' js=1}');
+                    window.showSuccessMessage('{l s='Successfully refreshed the favicon template. Do not forget to click "Save" below.' js=1}');
                   } else {
                    {if $smarty.const._PS_MODE_DEV_}
                      window.showErrorMessage(response.error);
@@ -155,7 +157,7 @@
     <div class="ace-container col-lg-9">
       <div class="ace-editor" data-name="{$key|escape:'htmlall':'UTF-8'}" id="ace{$key|escape:'htmlall':'UTF-8'}">{$field['value']|escape:'html':'UTF-8'}</div>
       <input type="hidden" id="{$key|escape:'htmlall':'UTF-8'}" name="{$key|escape:'htmlall':'UTF-8'}" value="{$field['value']|escape:'html':'UTF-8'}">
-      {if $key === 'TB_SOURCE_FAVICON_CODE'}
+      {if !empty($field['grab_favicon_template'])}
         <br />
         <button type="button" class="btn btn-default clearfix" onclick="downloadNewFaviconTemplate(event);"><i class="icon icon-download"></i> <span>{l s='Download a new template'}</span></button>
       {/if}

--- a/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/themes/helpers/options/options.tpl
@@ -25,134 +25,231 @@
 {extends file="helpers/options/options.tpl"}
 
 {block name="input"}
-	{if $field['type'] == 'theme'}
-		{if $field['can_display_themes']}
-			<div class="col-lg-12">
-				<div class="row">
-					{foreach $field.themes as $theme}
-						<div class="col-sm-4 col-lg-3">
-							<div class="theme-container">
-								<h4 class="theme-title">{$theme->name}</h4>
-								<div class="thumbnail-wrapper">
-									<div class="action-wrapper">
-										<div class="action-overlay"></div>
-										<div class="action-buttons">
-											<div class="btn-group">
-												<a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;submitOptionstheme&amp;id_theme={$theme->id}" class="btn btn-default">
-													<i class="icon-check"></i> {l s='Use this theme'}
-												</a>
-												{if $theme->name != 'community-theme-default' || ($theme->name == 'community-theme-default'  && $host_mode == 0)}
-												<button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-													<i class="icon-caret-down"></i>&nbsp;
-												</button>
-												<ul class="dropdown-menu">
-													<li>
-														<a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;deletetheme&amp;id_theme={$theme->id}" title="Delete this theme" class="delete">
-															<i class="icon-trash"></i> {l s='Delete this theme'}
-														</a>
-													</li>
-												</ul>
-												{/if}
-											</div>
-										</div>
-									</div>
-									<img class="center-block img-thumbnail" src="../themes/{$theme->directory}/preview.jpg" alt="{$theme->name}" />
-								</div>
-							</div>
-						</div>
-					{/foreach}
-					{foreach $field.not_installed as $theme}
-						<div class="col-sm-4 col-lg-3">
-							<div class="theme-container">
-								<h4 class="theme-title">{$theme.name}</h4>
-								<div class="thumbnail-wrapper">
-									<div class="action-wrapper">
-										<div class="action-overlay"></div>
-										<div class="action-buttons">
-											<div class="btn-group">
-												<a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;installThemeFromFolder&amp;theme_dir={$theme.directory}" class="btn btn-default">
-													<i class="icon-check"></i> {l s='Install this theme'}
-												</a>
-												<button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-													<i class="icon-caret-down"></i>&nbsp;
-												</button>
-												<ul class="dropdown-menu">
-													<li>
-														<a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;deletetheme&amp;theme_dir={$theme.directory}" title="Delete this theme" class="delete">
-															<i class="icon-trash"></i> {l s='Delete this theme'}
-														</a>
-													</li>
-												</ul>
-											</div>
-										</div>
-									</div>
-									<img class="center-block img-thumbnail" src="../themes/{$theme.directory}/themes/{$theme.directory}/preview.jpg" alt="{$theme.name}" />
-								</div>
-							</div>
-						</div>
-					{/foreach}
-				</div>
-			</div>
-		{/if}
-	{else}
-		{$smarty.block.parent}
-	{/if}
+  {if $field['type'] == 'theme'}
+    {if $field['can_display_themes']}
+      <div class="col-lg-12">
+        <div class="row">
+          {foreach $field.themes as $theme}
+            <div class="col-sm-4 col-lg-3">
+              <div class="theme-container">
+                <h4 class="theme-title">{$theme->name}</h4>
+                <div class="thumbnail-wrapper">
+                  <div class="action-wrapper">
+                    <div class="action-overlay"></div>
+                    <div class="action-buttons">
+                      <div class="btn-group">
+                        <a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;submitOptionstheme&amp;id_theme={$theme->id}" class="btn btn-default">
+                          <i class="icon-check"></i> {l s='Use this theme'}
+                        </a>
+                        {if $theme->name != 'community-theme-default' || ($theme->name == 'community-theme-default'  && $host_mode == 0)}
+                        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                          <i class="icon-caret-down"></i>&nbsp;
+                        </button>
+                        <ul class="dropdown-menu">
+                          <li>
+                            <a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;deletetheme&amp;id_theme={$theme->id}" title="Delete this theme" class="delete">
+                              <i class="icon-trash"></i> {l s='Delete this theme'}
+                            </a>
+                          </li>
+                        </ul>
+                        {/if}
+                      </div>
+                    </div>
+                  </div>
+                  <img class="center-block img-thumbnail" src="../themes/{$theme->directory}/preview.jpg" alt="{$theme->name}" />
+                </div>
+              </div>
+            </div>
+          {/foreach}
+          {foreach $field.not_installed as $theme}
+            <div class="col-sm-4 col-lg-3">
+              <div class="theme-container">
+                <h4 class="theme-title">{$theme.name}</h4>
+                <div class="thumbnail-wrapper">
+                  <div class="action-wrapper">
+                    <div class="action-overlay"></div>
+                    <div class="action-buttons">
+                      <div class="btn-group">
+                        <a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;installThemeFromFolder&amp;theme_dir={$theme.directory}" class="btn btn-default">
+                          <i class="icon-check"></i> {l s='Install this theme'}
+                        </a>
+                        <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                          <i class="icon-caret-down"></i>&nbsp;
+                        </button>
+                        <ul class="dropdown-menu">
+                          <li>
+                            <a href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;deletetheme&amp;theme_dir={$theme.directory}" title="Delete this theme" class="delete">
+                              <i class="icon-trash"></i> {l s='Delete this theme'}
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <img class="center-block img-thumbnail" src="../themes/{$theme.directory}/themes/{$theme.directory}/preview.jpg" alt="{$theme.name}" />
+                </div>
+              </div>
+            </div>
+          {/foreach}
+        </div>
+      </div>
+    {/if}
+  {elseif $field['type'] == 'code'}
+    {if $key === 'TB_SOURCE_FAVICON_CODE'}
+      <script type="text/javascript">
+        (function () {
+          function resetRefreshButton(target) {
+            target.innerHTML = '<i class="icon icon-download"></i> <span>{l s='Download a new template' js=1}</span>';
+          }
+
+          window.downloadNewFaviconTemplate = function (e) {
+            var target = e.target;
+            if (e.target.tagName !== 'BUTTON') {
+              target = e.target.parentNode;
+            }
+
+            var i = target.querySelector('i');
+            i.className = i.className.replace('icon-download', 'icon-refresh icon-spin');
+            var span = target.querySelector('span');
+            span.innerHTML = '{l s='Refreshing...' js=1}';
+
+            var request = new XMLHttpRequest();
+            request.open('GET', currentIndex + '&ajax=1&action=refreshFaviconTemplate&controller=AdminThemes&token=' + token, true);
+            request.onload = function() {
+              if (request.status >= 200 && request.status < 400) {
+                var response = request.responseText;
+                try {
+                  response = JSON.parse(response);
+                  if (!response.hasError) {
+                    document.getElementById('{$key|escape:'htmlall':'UTF-8'}').value = atob(response.template);
+                    window.aces['{$key|escape:'javascript':'UTF-8'}'].setValue(atob(response.template), -1);
+                    window.showSuccessMessage('{l s='Successfully refreshed the favicon template' js=1}');
+                  } else {
+                   {if $smarty.const._PS_MODE_DEV_}
+                     window.showErrorMessage(response.error);
+                   {/if}
+                  }
+                 } catch (e) {
+                  window.showErrorMessage('{l s='Unable to refresh template' js=1}');
+                  {if $smarty.const._PS_MODE_DEV_}
+                    window.showErrorMessage(JSON.stringify(e));
+                  {/if}
+
+                  resetRefreshButton(target);
+                }
+              }
+
+              resetRefreshButton(target);
+            };
+
+            request.onerror = function() {
+              resetRefreshButton(target);
+              window.showErrorMessage('{l s='Unable to refresh template' js=1}');
+            };
+
+            request.send();
+          };
+        }());
+      </script>
+    {/if}
+    <div class="ace-container col-lg-9">
+      <div class="ace-editor" data-name="{$key|escape:'htmlall':'UTF-8'}" id="ace{$key|escape:'htmlall':'UTF-8'}">{$field['value']|escape:'html':'UTF-8'}</div>
+      <input type="hidden" id="{$key|escape:'htmlall':'UTF-8'}" name="{$key|escape:'htmlall':'UTF-8'}" value="{$field['value']|escape:'html':'UTF-8'}">
+      {if $key === 'TB_SOURCE_FAVICON_CODE'}
+        <br />
+        <button type="button" class="btn btn-default clearfix" onclick="downloadNewFaviconTemplate(event);"><i class="icon icon-download"></i> <span>{l s='Download a new template'}</span></button>
+      {/if}
+    </div>
+    <script>
+      (function () {
+        function initAce() {
+          if (typeof ace === 'undefined') {
+            setTimeout(initAce, 100);
+            return;
+          }
+          var editor = ace.edit("ace{$key|escape:'htmlall':'UTF-8'}");
+          window.aces = window.aces || [];
+          window.aces['{$key|escape:'javascript':'UTF-8'}'] = editor;
+          editor.setTheme("ace/theme/xcode");
+          editor.getSession().setMode("ace/mode/{if isset($field['mode'])}{$field['mode']|escape:'javascript':'UTF-8'}{else}javascript{/if}");
+          editor.setOptions({
+            fontSize: {if isset($field['fontSize'])}{$field['fontSize']|intval}{else}14{/if},
+            minLines: {if isset($field['minLines'])}{$field['minLines']|intval}{else}10{/if},
+            maxLines: {if isset($field['maxLines'])}{$field['maxLines']|intval}{else}10{/if},
+            showPrintMargin: {if isset($field['showPrintMargin']) && $field['showPrintMargin']}true{else}false{/if},
+            enableBasicAutocompletion: {if isset($field['enableBasicAutocompletion']) && $field['enableBasicAutocompletion']}true{else}false{/if},
+            enableSnippets: {if isset($field['enableSnippets']) && $field['enableSnippets']}true{else}false{/if},
+            enableLiveAutocompletion: {if isset($field['enableLiveAutocompletion']) && $field['enableLiveAutocompletion']}true{else}false{/if}
+          });
+          var input_name = $('#ace{$key|escape:'htmlall':'UTF-8'}').attr('data-name');
+          $('#' + input_name).val(editor.getValue());
+          editor.on('change', function () {
+            $('#' + input_name).val(editor.getValue());
+          });
+        }
+
+        initAce();
+      })();
+    </script>
+  {else}
+    {$smarty.block.parent}
+  {/if}
 {/block}
 
 
 {block name="footer"}
 
-	{if isset($categoryData['after_tabs'])}
-		{assign var=cur_theme value=$categoryData['after_tabs']['cur_theme']}
-		<div class="row row-padding-top">
+  {if isset($categoryData['after_tabs'])}
+    {assign var=cur_theme value=$categoryData['after_tabs']['cur_theme']}
+    <div class="row row-padding-top">
 
-			<div class="col-md-3">
-				<a href="{$base_url}" class="_blank">
-					<img class="center-block img-thumbnail" src="../themes/{$cur_theme.theme_directory}/preview.jpg" alt="{$cur_theme.theme_name}" />
-				</a>
-			</div>
+      <div class="col-md-3">
+        <a href="{$base_url}" class="_blank">
+          <img class="center-block img-thumbnail" src="../themes/{$cur_theme.theme_directory}/preview.jpg" alt="{$cur_theme.theme_name}" />
+        </a>
+      </div>
 
-			<div id="js_theme_form_container" class="col-md-9">
-				<h2>{$cur_theme.theme_name} {if isset($cur_theme.theme_version)}<small>version {$cur_theme.theme_version}</small>{/if}</h2>
-				{if isset($cur_theme.author_name)}
-				<p>
-					{l s='Designed by %s' sprintf=$cur_theme.author_name}
-				</p>
-				{/if}
+      <div id="js_theme_form_container" class="col-md-9">
+        <h2>{$cur_theme.theme_name} {if isset($cur_theme.theme_version)}<small>version {$cur_theme.theme_version}</small>{/if}</h2>
+        {if isset($cur_theme.author_name)}
+        <p>
+          {l s='Designed by %s' sprintf=$cur_theme.author_name}
+        </p>
+        {/if}
 
-				{if isset($cur_theme.tc) && $cur_theme.tc}
-				<hr />
-				<h4>{l s='Customize your theme'}</h4>
-				<div class="row">
-					<div class="col-sm-8">
-						<p>{l s='Customize the main elements of your theme: sliders, banners, colors, etc.'}</p>
-					</div>
-					<div class="col-sm-4">
-						<a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminModules')|escape:'html':'UTF-8'}&amp;configure=themeconfigurator">
-							<i class="icon icon-list-alt"></i>
-							{l s='Theme Configurator'}
-						</a>
-					</div>
-				</div>
-				{/if}
-				<hr />
-				<h4>{l s='Configure your theme'}</h4>
-				<div class="row">
-					<div class="col-sm-8">
-						<p>{l s='Configure your theme\'s advanced settings, such as the number of columns you want for each page. This setting is mostly for advanced users.'}</p>
-					</div>
-					<div class="col-sm-4">
-						<a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;updatetheme&amp;id_theme={$cur_theme.theme_id}">
-							<i class="icon icon-cog"></i>
-							{l s='Advanced settings'}
-						</a>
-					</div>
-				</div>
-			</div>
-		</div>
+        {if isset($cur_theme.tc) && $cur_theme.tc}
+        <hr />
+        <h4>{l s='Customize your theme'}</h4>
+        <div class="row">
+          <div class="col-sm-8">
+            <p>{l s='Customize the main elements of your theme: sliders, banners, colors, etc.'}</p>
+          </div>
+          <div class="col-sm-4">
+            <a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminModules')|escape:'html':'UTF-8'}&amp;configure=themeconfigurator">
+              <i class="icon icon-list-alt"></i>
+              {l s='Theme Configurator'}
+            </a>
+          </div>
+        </div>
+        {/if}
+        <hr />
+        <h4>{l s='Configure your theme'}</h4>
+        <div class="row">
+          <div class="col-sm-8">
+            <p>{l s='Configure your theme\'s advanced settings, such as the number of columns you want for each page. This setting is mostly for advanced users.'}</p>
+          </div>
+          <div class="col-sm-4">
+            <a class="btn btn-default pull-right" href="{$link->getAdminLink('AdminThemes')|escape:'html':'UTF-8'}&amp;updatetheme&amp;id_theme={$cur_theme.theme_id}">
+              <i class="icon icon-cog"></i>
+              {l s='Advanced settings'}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
 
-	{/if}
+  {/if}
 
-	{$smarty.block.parent}
+  {$smarty.block.parent}
 
 {/block}

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -666,4 +666,130 @@ class ImageManagerCore
 
         return $mimeType;
     }
+
+
+    /**
+     * Add an image to the generator.
+     *
+     * This function adds a source image to the generator. It serves two main purposes: add a source image if one was
+     * not supplied to the constructor and to add additional source images so that different images can be supplied for
+     * different sized images in the resulting ICO file. For instance, a small source image can be used for the small
+     * resolutions while a larger source image can be used for large resolutions.
+     *
+     * @param string $source Path to the source image file.
+     * @param array  $sizes  Optional. An array of sizes (each size is an array with a width and height) that the source image should be rendered at in the generated ICO file. If sizes are not supplied, the size of the source image will be used.
+     *
+     * @return boolean true on success and false on failure.
+     */
+    public static function generateFavicon($source, $sizes = [['16', '16'], ['32', '32'], ['48', '48']])
+    {
+        $images = [];
+
+        if (!$size = getimagesize($source)) {
+            return false;
+        }
+        if (!$file_data = file_get_contents($source)) {
+            return false;
+        }
+        if (!$im = imagecreatefromstring($file_data)) {
+            return false;
+        }
+        unset($file_data);
+        if (empty($sizes)) {
+            $sizes = array(imagesx($im), imagesy($im));
+        }
+
+        // If just a single size was passed, put it in array.
+        if ( ! is_array( $sizes[0] ) ) {
+            $sizes = array( $sizes );
+        }
+
+        foreach ( (array) $sizes as $size ) {
+            list( $width, $height ) = $size;
+            $new_im = imagecreatetruecolor( $width, $height );
+            imagecolortransparent( $new_im, imagecolorallocatealpha( $new_im, 0, 0, 0, 127 ) );
+            imagealphablending( $new_im, false );
+            imagesavealpha( $new_im, true );
+            $source_width = imagesx( $im );
+            $source_height = imagesy( $im );
+            if ( false === imagecopyresampled( $new_im, $im, 0, 0, 0, 0, $width, $height, $source_width, $source_height ) )
+                continue;
+
+            static::addFaviconImageData($new_im, $images);
+        }
+
+        return static::getIcoData($images);
+    }
+
+    /**
+     * Generate the final ICO data by creating a file header and adding the image data.
+     */
+    protected static function getIcoData($images)
+    {
+        if (!is_array($images) || empty($images))
+            return false;
+        $data = pack('vvv', 0, 1, count($images));
+        $pixel_data = '';
+        $icon_dir_entry_size = 16;
+        $offset = 6 + ($icon_dir_entry_size * count($images));
+        foreach ($images as $image) {
+            $data .= pack('CCCCvvVV', $image['width'], $image['height'], $image['color_palette_colors'], 0, 1, $image['bits_per_pixel'], $image['size'], $offset);
+            $pixel_data .= $image['data'];
+            $offset += $image['size'];
+        }
+        $data .= $pixel_data;
+        unset($pixel_data);
+        return $data;
+    }
+
+    /**
+     * Take a GD image resource and change it into a raw BMP format.
+     */
+    protected static function addFaviconImageData($im, &$images)
+    {
+        $width = imagesx($im);
+        $height = imagesy($im);
+        $pixel_data = array();
+        $opacity_data = array();
+        $current_opacity_val = 0;
+        for ($y = $height - 1; $y >= 0; $y--) {
+            for ($x = 0; $x < $width; $x++) {
+                $color = imagecolorat($im, $x, $y);
+                $alpha = ($color & 0x7F000000) >> 24;
+                $alpha = (1 - ($alpha / 127)) * 255;
+                $color &= 0xFFFFFF;
+                $color |= 0xFF000000 & ($alpha << 24);
+                $pixel_data[] = $color;
+                $opacity = ($alpha <= 127) ? 1 : 0;
+                $current_opacity_val = ($current_opacity_val << 1) | $opacity;
+                if ((($x + 1) % 32) == 0) {
+                    $opacity_data[] = $current_opacity_val;
+                    $current_opacity_val = 0;
+                }
+            }
+            if (($x % 32) > 0) {
+                while (($x++ % 32) > 0)
+                    $current_opacity_val = $current_opacity_val << 1;
+                $opacity_data[] = $current_opacity_val;
+                $current_opacity_val = 0;
+            }
+        }
+        $image_header_size = 40;
+        $color_mask_size = $width * $height * 4;
+        $opacity_mask_size = (ceil($width / 32) * 4) * $height;
+        $data = pack('VVVvvVVVVVV', 40, $width, ($height * 2), 1, 32, 0, 0, 0, 0, 0, 0);
+        foreach ($pixel_data as $color)
+            $data .= pack('V', $color);
+        foreach ($opacity_data as $opacity)
+            $data .= pack('N', $opacity);
+        $image = array(
+            'width'                => $width,
+            'height'               => $height,
+            'color_palette_colors' => 0,
+            'bits_per_pixel'       => 32,
+            'size'                 => $image_header_size + $color_mask_size + $opacity_mask_size,
+            'data'                 => $data,
+        );
+        $images[] = $image;
+    }
 }

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -680,6 +680,11 @@ class ImageManagerCore
      * @param array  $sizes  Optional. An array of sizes (each size is an array with a width and height) that the source image should be rendered at in the generated ICO file. If sizes are not supplied, the size of the source image will be used.
      *
      * @return boolean true on success and false on failure.
+     *
+     * @copyright 2011-2016  Chris Jean
+     * @author Chris Jean
+     * @license GNU General Public License v2.0
+     * @source https://github.com/chrisbliss18/php-ico
      */
     public static function generateFavicon($source, $sizes = [['16', '16'], ['32', '32'], ['48', '48']])
     {
@@ -696,12 +701,12 @@ class ImageManagerCore
         }
         unset($file_data);
         if (empty($sizes)) {
-            $sizes = array(imagesx($im), imagesy($im));
+            $sizes = [imagesx($im), imagesy($im)];
         }
 
         // If just a single size was passed, put it in array.
         if ( ! is_array( $sizes[0] ) ) {
-            $sizes = array( $sizes );
+            $sizes = [$sizes];
         }
 
         foreach ( (array) $sizes as $size ) {
@@ -723,6 +728,11 @@ class ImageManagerCore
 
     /**
      * Generate the final ICO data by creating a file header and adding the image data.
+     *
+     * @copyright 2011-2016  Chris Jean
+     * @author Chris Jean
+     * @license GNU General Public License v2.0
+     * @source https://github.com/chrisbliss18/php-ico
      */
     protected static function getIcoData($images)
     {
@@ -744,13 +754,18 @@ class ImageManagerCore
 
     /**
      * Take a GD image resource and change it into a raw BMP format.
+     *
+     * @copyright 2011-2016  Chris Jean
+     * @author Chris Jean
+     * @license GNU General Public License v2.0
+     * @source https://github.com/chrisbliss18/php-ico
      */
     protected static function addFaviconImageData($im, &$images)
     {
         $width = imagesx($im);
         $height = imagesy($im);
-        $pixel_data = array();
-        $opacity_data = array();
+        $pixel_data = [];
+        $opacity_data = [];
         $current_opacity_val = 0;
         for ($y = $height - 1; $y >= 0; $y--) {
             for ($x = 0; $x < $width; $x++) {
@@ -768,8 +783,9 @@ class ImageManagerCore
                 }
             }
             if (($x % 32) > 0) {
-                while (($x++ % 32) > 0)
+                while (($x++ % 32) > 0) {
                     $current_opacity_val = $current_opacity_val << 1;
+                }
                 $opacity_data[] = $current_opacity_val;
                 $current_opacity_val = 0;
             }
@@ -778,18 +794,20 @@ class ImageManagerCore
         $color_mask_size = $width * $height * 4;
         $opacity_mask_size = (ceil($width / 32) * 4) * $height;
         $data = pack('VVVvvVVVVVV', 40, $width, ($height * 2), 1, 32, 0, 0, 0, 0, 0, 0);
-        foreach ($pixel_data as $color)
+        foreach ($pixel_data as $color) {
             $data .= pack('V', $color);
-        foreach ($opacity_data as $opacity)
+        }
+        foreach ($opacity_data as $opacity) {
             $data .= pack('N', $opacity);
-        $image = array(
+        }
+        $image = [
             'width'                => $width,
             'height'               => $height,
             'color_palette_colors' => 0,
             'bits_per_pixel'       => 32,
             'size'                 => $image_header_size + $color_mask_size + $opacity_mask_size,
             'data'                 => $data,
-        );
+        ];
         $images[] = $image;
     }
 }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -5234,6 +5234,60 @@ exit;
     {
         return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
     }
+
+    /**
+     * Grabs a size tag from a DOMElement (as HTML)
+     *
+     * @param string $html
+     *
+     * @return array|false
+     *
+     * @since 1.0.4
+     */
+    public static function parseFaviconSizeTag($html)
+    {
+        $srcFound = false;
+        $favicon = [];
+        preg_match('/\{(.*)\}/U', $html, $m);
+        if (!$m || count($m) < 2) {
+            return false;
+        }
+        $tags = explode(' ', $m[1]);
+        foreach ($tags as $tag) {
+            $components = explode('=', $tag);
+            if (count($components) === 1) {
+                if ($components[0] === 'src') {
+                    $srcFound = true;
+                }
+
+                continue;
+            }
+
+            switch ($components[0]) {
+                case 'type':
+                    $favicon['type'] = $components[1];
+                    break;
+                case 'size':
+                    $dimension = explode('x', $components[1]);
+                    if (count($dimension) !== 2) {
+                        continue;
+                    }
+                    $favicon['width'] = $dimension[0];
+                    $favicon['height'] = $dimension[1];
+                    break;
+            }
+        }
+
+        if ($srcFound && array_key_exists('width', $favicon) && array_key_exists('height', $favicon)) {
+            if (!isset($favicon['type'])) {
+                $favicon['type'] = 'png';
+            }
+
+            return $favicon;
+        }
+
+        return false;
+    }
 }
 
 /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -261,18 +261,31 @@ class FrontControllerCore extends Controller
             // Needed hooks are called in the tpl files.
 
             $hookHeader = Hook::exec('displayHeader');
-            foreach ([
-                         Media::FAVICON_57  => '57',
-                         Media::FAVICON_72  => '72',
-                         Media::FAVICON_114 => '114',
-                         Media::FAVICON_192 => '192',
-                     ] as $faviconType => $size) {
-                if ($path = Media::getFaviconPath($faviconType)) {
-                    $hookHeader .= '<link rel="icon" sizes="'.$size.'x'.$size.'" href="'.$path.'">';
+
+            $faviconTemplate = Configuration::get('TB_SOURCE_FAVICON_CODE');
+            if ($faviconTemplate) {
+                $dom = new DOMDocument();
+                $dom->loadHTML($faviconTemplate);
+                $links = [];
+                foreach ($dom->getElementsByTagName('link') as $elem) {
+                    $links[] = $elem;
                 }
-            }
-            if ($path = Media::getFaviconPath(Media::FAVICON_144)) {
-                $hookHeader .= '<link rel="apple-touch-icon" sizes="144x144" href="'.$path.'">';
+                foreach ($dom->getElementsByTagName('meta') as $elem) {
+                    $links[] = $elem;
+                }
+                $faviconHtml = '';
+                foreach ($links as $link) {
+                    foreach ($link->attributes as $attribute) {
+                        /** @var DOMElement $link */
+                        if ($favicon = Tools::parseFaviconSizeTag(urldecode($attribute->value))) {
+                            $attribute->value = Media::getMediaPath(_PS_IMG_DIR_."favicon/favicon_{$this->context->shop->id}_{$favicon['width']}_{$favicon['height']}.{$favicon['type']}");
+                        }
+                    }
+                    $faviconHtml .= $dom->saveHTML($link);
+                }
+                if ($faviconHtml) {
+                    $hookHeader .= $faviconHtml;
+                }
             }
 
             if (isset($this->php_self)) { // append some seo fields, canonical, hrefLang, rel prev/next

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -286,6 +286,8 @@ class FrontControllerCore extends Controller
                 if ($faviconHtml) {
                     $hookHeader .= $faviconHtml;
                 }
+                $hookHeader .= '<meta name="msapplication-config" content="'.Media::getMediaPath(_PS_IMG_DIR_."favicon/browserconfig_{$this->context->shop->id}.xml").'">';
+                $hookHeader .= '<link rel="manifest" href="'.Media::getMediaPath(_PS_IMG_DIR_."favicon/manifest_{$this->context->shop->id}.json").'">';
             }
 
             if (isset($this->php_self)) { // append some seo fields, canonical, hrefLang, rel prev/next

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -211,7 +211,7 @@ class AdminThemesControllerCore extends AdminController
                         'type'  => 'file',
                         'name'  => 'TB_SOURCE_FAVICON',
                         'tab'   => 'icons',
-                        'thumb' => $this->thumbnail(_PS_IMG_DIR_."favicon/favicon_{$this->context->shop->id}_source.png", 'favicon_source.png', 512, true, true),
+                        'thumb' => $this->thumbnail(_PS_IMG_DIR_."favicon/favicon_{$this->context->shop->id}_source.png", 'favicon_source.png', 512, 'png', true, true),
                     ],
                     'TB_SOURCE_FAVICON_CODE'   => [
                         'title'                     => $this->l('Favicon metas'),
@@ -3062,8 +3062,8 @@ class AdminThemesControllerCore extends AdminController
         $manifest = [
             'name'             => Configuration::get('PS_SHOP_NAME'),
             'icons'            => [],
-            'theme_color'      => '#ffffff',
-            'background_color' => '#000000',
+            'theme_color'      => '#fad629',
+            'background_color' => '#fad629',
             'display'          => 'standalone',
         ];
 
@@ -3086,7 +3086,7 @@ class AdminThemesControllerCore extends AdminController
                         _PS_IMG_DIR_."favicon/favicon_{$idShop}_{$favicon['width']}_{$favicon['height']}.png",
                         (int) $favicon['width'],
                         (int) $favicon['height'],
-                        $favicon['type']
+                        'png'
                     );
 
                     if (in_array("{$favicon['width']}x{$favicon['height']}", [
@@ -3107,6 +3107,13 @@ class AdminThemesControllerCore extends AdminController
                         'sizes' => "{$favicon['width']}x{$favicon['height']}",
                         'type'  => "image/{$favicon['type']}",
                     ];
+                }
+
+                if ($link->hasAttribute('name') && $link->getAttribute('name') === 'theme-color') {
+                    $manifest['theme_color'] = $link->getAttribute('content');
+                }
+                if ($link->hasAttribute('name') && $link->getAttribute('name') === 'background-color') {
+                    $manifest['background_color'] = $link->getAttribute('content');
                 }
             }
             $filteredHtml .= $dom->saveHTML($link);
@@ -3137,8 +3144,10 @@ class AdminThemesControllerCore extends AdminController
             // Check ico validity
             if ($error = ImageManager::validateIconUpload($_FILES[$name])) {
                 $this->errors[] = $name . ': ' . $error;
-            } elseif (!@file_put_contents($dest, ImageManager::generateFavicon($_FILES[$name]['tmp_name']))) {
+            } elseif (mb_substr($dest, -3) === 'ico' && !@file_put_contents($dest, ImageManager::generateFavicon($_FILES[$name]['tmp_name']))) {
                 // Copy new ico
+                $this->errors[] = sprintf(Tools::displayError('An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".'), $_FILES[$name]['tmp_name'], $dest);
+            } elseif (mb_substr($dest, -3) !== 'ico' && !@copy($_FILES[$name]['tmp_name'], $dest)) {
                 $this->errors[] = sprintf(Tools::displayError('An error occurred while uploading the favicon: cannot copy file "%s" to folder "%s".'), $_FILES[$name]['tmp_name'], $dest);
             }
         }

--- a/controllers/admin/AdminThemesController.php
+++ b/controllers/admin/AdminThemesController.php
@@ -48,7 +48,7 @@ class AdminThemesControllerCore extends AdminController
     public static $check_features_version = '1.4';
     /**
      * Multidimensional array used to check [theme]/config.xml values,
-     * and also checks prestashop current configuration if not match.
+     * and also checks thirty bees current configuration if not match.
      *
      * @var array
      */
@@ -58,7 +58,7 @@ class AdminThemesControllerCore extends AdminController
                 'available' => [
                     'value'              => 'true',
                     /*
-                     * accepted attribute value if value doesn't match, prestashop configuration value must have those values
+                     * accepted attribute value if value doesn't match, thirty bees configuration value must have those values
                     */
                     'check_if_not_valid' => [
                         'PS_CSS_THEME_CACHE'           => 0,
@@ -125,6 +125,7 @@ class AdminThemesControllerCore extends AdminController
      * AdminThemesControllerCore constructor.
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function __construct()
     {
@@ -137,6 +138,10 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function init()
@@ -198,45 +203,28 @@ class AdminThemesControllerCore extends AdminController
                         'tab'   => 'icons',
                         'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon.ico'),
                     ],
-                    'PS_FAVICON_57'   => [
-                        'title' => $this->l('iPhone/iPad Favicon 57px (PNG)'),
+                    'TB_SOURCE_FAVICON'  => [
+                        'title' => $this->l('Source favicon (PNG)'),
                         'hint'  => $this->l('Will appear in the address bar of your web browser.'),
+                        'desc'  => $this->l('Make sure you upload a big enough favicon. Preferrably one that covers all sizes.'),
                         'type'  => 'file',
-                        'name'  => 'PS_FAVICON_57',
+                        'name'  => 'TB_SOURCE_FAVICON',
                         'tab'   => 'icons',
-                        'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon_57.png'),
+                        'thumb' => $this->thumbnail(_PS_IMG_DIR_."favicon/favicon_{$this->context->shop->id}_source.png", 'favicon_source', 256),
                     ],
-                    'PS_FAVICON_72'   => [
-                        'title' => $this->l('iPhone/iPad Favicon 72px (PNG)'),
-                        'hint'  => $this->l('Will appear in the address bar of your web browser.'),
-                        'type'  => 'file',
-                        'name'  => 'PS_FAVICON_72',
-                        'tab'   => 'icons',
-                        'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon_72.png'),
-                    ],
-                    'PS_FAVICON_114'  => [
-                        'title' => $this->l('iPhone/iPad Favicon 114px (PNG)'),
-                        'hint'  => $this->l('Will appear in the address bar of your web browser.'),
-                        'type'  => 'file',
-                        'name'  => 'PS_FAVICON_114',
-                        'tab'   => 'icons',
-                        'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon_114.png'),
-                    ],
-                    'PS_FAVICON_144'  => [
-                        'title' => $this->l('iPhone/iPad Favicon 144px (PNG)'),
-                        'hint'  => $this->l('Will appear in the address bar of your web browser.'),
-                        'type'  => 'file',
-                        'name'  => 'PS_FAVICON_144',
-                        'tab'   => 'icons',
-                        'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon_144.png'),
-                    ],
-                    'PS_FAVICON_192'  => [
-                        'title' => $this->l('Android Chrome Favicon 192 (PNG)'),
-                        'hint'  => $this->l('Will appear in the address bar of your web browser.'),
-                        'type'  => 'file',
-                        'name'  => 'PS_FAVICON_192',
-                        'tab'   => 'icons',
-                        'thumb' => Media::getMediaPath(_PS_IMG_DIR_.'favicon_192.png'),
+                    'TB_SOURCE_FAVICON_CODE'   => [
+                        'title'                     => $this->l('Favicon metas'),
+                        'hint'                      => $this->l('The literal favicon meta code that gets included on every page.'),
+                        'type'                      => 'code',
+                        'mode'                      => 'html',
+                        'enableBasicAutocompletion' => true,
+                        'enableSnippets'            => true,
+                        'enableLiveAutocompletion'  => true,
+                        'visibility'                => Shop::CONTEXT_ALL,
+                        'minLines'                  => 20,
+                        'maxLines'                  => 30,
+                        'tab'                       => 'icons',
+                        'grab_favicon_template'     => true,
                     ],
                     'PS_STORES_ICON'  => [
                         'title' => $this->l('Store icon'),
@@ -280,6 +268,10 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderForm()
@@ -426,7 +418,7 @@ class AdminThemesControllerCore extends AdminController
                 'label'    => $this->l('Name of the theme\'s directory'),
                 'name'     => 'directory',
                 'required' => true,
-                'hint'     => $this->l('If the directory does not exist, PrestaShop will create it automatically.'),
+                'hint'     => $this->l('If the directory does not exist, thirty bees will create it automatically.'),
             ];
 
             $themeQuery = Theme::getThemes();
@@ -520,6 +512,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return false|string
      *
+     * @throws PrestaShopException
+     * @throws PrestaShopExceptionCore
      * @since 1.0.0
      */
     public function renderList()
@@ -543,6 +537,7 @@ class AdminThemesControllerCore extends AdminController
      * @return bool|Theme
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function processAdd()
     {
@@ -645,6 +640,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processUpdate()
@@ -687,6 +684,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return bool|false|ObjectModel
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processDelete()
@@ -731,6 +730,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws Adapter_Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processExportTheme()
@@ -1093,6 +1095,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return bool
      *
+     * @throws Adapter_Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function checkParentClass($name)
@@ -1122,10 +1127,11 @@ class AdminThemesControllerCore extends AdminController
     /**
      * Generate XML
      *
-     * @param $themeToExport
-     * @param $metas
+     * @param Theme $themeToExport
+     * @param array $metas
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     protected function generateXML($themeToExport, $metas)
     {
@@ -1328,6 +1334,11 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Adapter_Exception
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderExportTheme()
@@ -1386,6 +1397,11 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Adapter_Exception
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     protected function renderExportTheme1()
@@ -1595,6 +1611,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return array
      *
+     * @throws Adapter_Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function formatHelperArray($originArr)
@@ -1624,6 +1643,7 @@ class AdminThemesControllerCore extends AdminController
      * @return bool
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function processImportTheme()
     {
@@ -1734,6 +1754,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return bool
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function installTheme($themeDir, $sandbox = false, $redirect = true)
@@ -1828,6 +1850,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return array|string return array of themes on success, otherwise the error as a string is returned
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function importThemeXmlConfig(SimpleXMLElement $xml, $themeDir = false)
@@ -1949,6 +1973,7 @@ class AdminThemesControllerCore extends AdminController
      * @return bool
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     protected function isThemeInstalled($themeName)
     {
@@ -1969,6 +1994,10 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderImportTheme()
@@ -2097,6 +2126,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws Exception
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function initContent()
@@ -2138,6 +2170,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function initPageHeaderToolbar()
     {
@@ -2186,6 +2219,11 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Adapter_Exception
+     * @throws Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderChooseThemeModule()
@@ -2451,6 +2489,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws Adapter_Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processThemeInstall()
@@ -2592,6 +2633,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return array
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function updateImages($xml)
@@ -2634,6 +2677,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     protected function hookModule($idModule, $moduleHooks, $shop)
@@ -2674,6 +2719,9 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Exception
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderView()
@@ -2687,7 +2735,7 @@ class AdminThemesControllerCore extends AdminController
             'image_link'     => $this->context->link->getAdminLink('AdminImages'),
         ];
 
-        return parent::renderView();
+        parent::renderView();
     }
 
     /**
@@ -2727,6 +2775,7 @@ class AdminThemesControllerCore extends AdminController
      * @return bool Validity is ok or not
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     protected function _isThemeCompatible($themeDir)
     {
@@ -2778,6 +2827,8 @@ class AdminThemesControllerCore extends AdminController
      * @param mixed $configItem  will precise the attribute which not matches. If empty, will check every attributes
      *
      * @return bool Error message, or null if disabled
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      */
     protected function _checkConfigForFeatures($arrFeatures, $configItem = [])
     {
@@ -2837,6 +2888,7 @@ class AdminThemesControllerCore extends AdminController
      * @return bool
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     protected function updateLogo($fieldName, $logoPrefix)
     {
@@ -2913,6 +2965,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function updateOptionPsLogoMail()
     {
@@ -2925,6 +2978,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function updateOptionPsLogoInvoice()
     {
@@ -2937,6 +2991,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function updateOptionPsStoresIcon()
     {
@@ -2949,6 +3004,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon()
     {
@@ -2962,6 +3018,59 @@ class AdminThemesControllerCore extends AdminController
         }
 
         Configuration::updateGlobalValue('PS_FAVICON', 'favicon.ico');
+
+        if (!$this->errors) {
+            $this->redirect_after = static::$currentIndex.'&token='.$this->token;
+        }
+    }
+
+    /**
+     * Process the favicon sizes
+     *
+     * @since 1.0.4
+     */
+    public function updateOptionTbSourceFaviconCode()
+    {
+        if (!file_exists(_PS_IMG_DIR_.'favicon')) {
+            $definedUmask = defined('_TB_UMASK_') ? _TB_UMASK_ : 0000;
+            $previousUmask = @umask($definedUmask);
+            mkdir(_PS_IMG_DIR_.'favicon', 0777);
+            @umask($previousUmask);
+        }
+
+        $idShop = (int) $this->context->shop->id;
+        $this->uploadIco('TB_SOURCE_FAVICON', _PS_IMG_DIR_."favicon/favicon_{$idShop}_source.png");
+
+        $newTemplate = Tools::getValue('TB_SOURCE_FAVICON_CODE');
+        $filteredHtml = '';
+
+        // Filter and detect sizes
+        $dom = new DOMDocument();
+        $dom->loadHTML($newTemplate);
+        $links = [];
+        foreach ($dom->getElementsByTagName('link') as $elem) {
+            $links[] = $elem;
+        }
+        foreach ($dom->getElementsByTagName('meta') as $elem) {
+            $links[] = $elem;
+        }
+        foreach ($links as $link) {
+            foreach ($link->attributes as $attribute) {
+                /** @var DOMElement $link */
+                if ($favicon = Tools::parseFaviconSizeTag(urldecode($attribute->value))) {
+                    ImageManager::resize(
+                        _PS_IMG_DIR_."favicon/favicon_{$idShop}_source.png",
+                        _PS_IMG_DIR_."favicon/favicon_{$idShop}_{$favicon['width']}_{$favicon['height']}.png",
+                        (int) $favicon['width'],
+                        (int) $favicon['height'],
+                        $favicon['type']
+                    );
+                }
+            }
+            $filteredHtml .= $dom->saveHTML($link);
+        }
+
+        Configuration::updateValue('TB_SOURCE_FAVICON_CODE', urldecode($filteredHtml), true);
 
         if (!$this->errors) {
             $this->redirect_after = static::$currentIndex.'&token='.$this->token;
@@ -2999,6 +3108,8 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @deprecated 1.0.4
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon_57()
     {
@@ -3022,6 +3133,8 @@ class AdminThemesControllerCore extends AdminController
      * Update PS_FAVICON_72
      *
      * @since 1.0.0
+     * @deprecated 1.0.4
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon_72()
     {
@@ -3045,6 +3158,8 @@ class AdminThemesControllerCore extends AdminController
      * Update PS_FAVICON_114
      *
      * @since 1.0.0
+     * @deprecated 1.0.4
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon_114()
     {
@@ -3068,6 +3183,8 @@ class AdminThemesControllerCore extends AdminController
      * Update PS_FAVICON_144
      *
      * @since 1.0.0
+     * @deprecated 1.0.4
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon_144()
     {
@@ -3091,6 +3208,8 @@ class AdminThemesControllerCore extends AdminController
      * Update PS_FAVICON_192
      *
      * @since 1.0.0
+     * @deprecated 1.0.4
+     * @throws PrestaShopException
      */
     public function updateOptionPsFavicon_192()
     {
@@ -3111,10 +3230,46 @@ class AdminThemesControllerCore extends AdminController
     }
 
     /**
+     * Refresh the favicon template
+     *
+     * @since 1.0.4 to enable the favicon template
+     */
+    function ajaxProcessRefreshFaviconTemplate()
+    {
+        try {
+            $template = (string) (new \GuzzleHttp\Client([
+                'http_errors' => false,
+                'verify'      => _PS_TOOL_DIR_.'cacert.pem',
+                'timeout'     => 60,
+            ]))->get('https://raw.githubusercontent.com/thirtybees/favicons/master/template.html')->getBody();
+        } catch (Exception $e) {
+            $this->ajaxDie(json_encode([
+                'hasError' => true,
+                'error'    => $e->getMessage(),
+            ]));
+        }
+
+        if (!$template) {
+            $this->ajaxDie(json_encode([
+                'hasError' => true,
+                'error' => '',
+            ]));
+        }
+
+        $this->ajaxDie(json_encode([
+            'hasError' => false,
+            'template' => base64_encode($template),
+            'error'    => '',
+        ]));
+    }
+
+    /**
      * Update theme for current shop
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function updateOptionThemeForShop()
@@ -3203,6 +3358,7 @@ class AdminThemesControllerCore extends AdminController
      * @return false|ObjectModel|Theme
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function processResponsive()
     {
@@ -3226,6 +3382,7 @@ class AdminThemesControllerCore extends AdminController
      * @return false|ObjectModel|Theme
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function processDefaultLeftColumn()
     {
@@ -3249,6 +3406,7 @@ class AdminThemesControllerCore extends AdminController
      * @return false|ObjectModel|Theme
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     public function processDefaultRightColumn()
     {
@@ -3271,6 +3429,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function ajaxProcessLeftMeta()
@@ -3297,6 +3457,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processLeftMeta()
@@ -3329,6 +3491,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @sicne 1.0.0
      */
     public function ajaxProcessRightMeta()
@@ -3354,6 +3518,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function processRightMeta()
@@ -3386,6 +3552,11 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return string
      *
+     * @throws Exception
+     * @throws HTMLPurifier_Exception
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
      * @since 1.0.0
      */
     public function renderOptions()
@@ -3420,6 +3591,8 @@ class AdminThemesControllerCore extends AdminController
      *
      * @return void
      *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
      * @since 1.0.0
      */
     public function setMedia()
@@ -3434,6 +3607,7 @@ class AdminThemesControllerCore extends AdminController
      * @return void
      *
      * @since 1.0.0
+     * @throws PrestaShopException
      */
     protected function processUpdateOptions()
     {
@@ -3476,5 +3650,63 @@ class AdminThemesControllerCore extends AdminController
             }
         }
         closedir($dir);
+    }
+
+    /**
+     * Generate a cached thumbnail for object lists (eg. carrier, order statuses...etc)
+     *
+     * @param string $image        Real image filename
+     * @param string $cacheImage   Cached filename
+     * @param int    $size         Desired size
+     * @param string $imageType    Image type
+     * @param bool   $disableCache When turned on a timestamp will be added to the image URI to disable the HTTP cache
+     * @param bool   $regenerate   When turned on and the file already exist, the file will be regenerated
+     *
+     * @return string
+     *
+     * @since   1.0.4
+     */
+    protected function thumbnail($image, $cacheImage, $size, $imageType = 'jpg', $disableCache = true, $regenerate = false)
+    {
+        if (!file_exists($image)) {
+            return '';
+        }
+
+        if (file_exists(_PS_TMP_IMG_DIR_.$cacheImage) && $regenerate) {
+            @unlink(_PS_TMP_IMG_DIR_.$cacheImage);
+        }
+
+        if ($regenerate || !file_exists(_PS_TMP_IMG_DIR_.$cacheImage)) {
+            $infos = getimagesize($image);
+
+            // Evaluate the memory required to resize the image: if it's too much, you can't resize it.
+            if (!ImageManager::checkImageMemoryLimit($image)) {
+                return false;
+            }
+
+            $x = $infos[0];
+            $y = $infos[1];
+            $maxX = $size * 3;
+
+            // Size is already ok
+            if ($y < $size && $x <= $maxX) {
+                copy($image, _PS_TMP_IMG_DIR_.$cacheImage);
+            } // We need to resize */
+            else {
+                $ratio_x = $x / ($y / $size);
+                if ($ratio_x > $maxX) {
+                    $ratio_x = $maxX;
+                    $size = $y / ($x / $maxX);
+                }
+
+                ImageManager::resize($image, _PS_TMP_IMG_DIR_.$cacheImage, $ratio_x, $size, $imageType);
+            }
+        }
+        // Relative link will always work, whatever the base uri set in the admin
+        if (Context::getContext()->controller->controller_type == 'admin') {
+            return '../img/tmp/'.$cacheImage.($disableCache ? '?time='.time() : '');
+        } else {
+            return _PS_TMP_IMG_.$cacheImage.($disableCache ? '?time='.time() : '');
+        }
     }
 }

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -877,8 +877,37 @@
     <configuration id="PS_ROUTE_cms_category_rule" name="PS_ROUTE_cms_category_rule">
       <value>info/{rewrite}</value>
     </configuration>
-    <configuration id="PS_SHOW_CONDITION'" name="PS_SHOW_CONDITION'">
+    <configuration id="PS_SHOW_CONDITION" name="PS_SHOW_CONDITION">
       <value>1</value>
+    </configuration>
+    <configuration id="TB_SOURCE_FAVICON_CODE" name="TB_SOURCE_FAVICON_CODE">
+      <value><![CDATA[<link rel="apple-touch-icon" sizes="57x57" href="{src size=57x57 type=png}">
+<link rel="apple-touch-icon" sizes="60x60" href="{src size=60x60 type=png}">
+<link rel="apple-touch-icon" sizes="72x72" href="{src size=72x72 type=png}">
+<link rel="apple-touch-icon" sizes="76x76" href="{src size=76x76 type=png}">
+<link rel="apple-touch-icon" sizes="114x114" href="{src size=114x114 type=png}">
+<link rel="apple-touch-icon" sizes="120x120" href="{src size=120x120 type=png}">
+<link rel="apple-touch-icon" sizes="144x144" href="{src size=144x144 type=png}">
+<link rel="apple-touch-icon" sizes="152x152" href="{src size=152x152 type=png}">
+<link rel="apple-touch-icon" sizes="180x180" href="{src size=180x180 type=png}">
+<link rel="icon" type="image/png" sizes="16x16" href="{src size=16x16 type=png}">
+<link rel="icon" type="image/png" sizes="32x32" href="{src size=32x32 type=png}">
+<link rel="icon" type="image/png" sizes="36x36" href="{src size=36x36 type=png}">
+<link rel="icon" type="image/png" sizes="48x48" href="{src size=48x48 type=png}">
+<link rel="icon" type="image/png" sizes="72x72" href="{src size=72x72 type=png}">
+<link rel="icon" type="image/png" sizes="96x96" href="{src size=96x96 type=png}">
+<link rel="icon" type="image/png" sizes="144x144" href="{src size=144x144 type=png}">
+<link rel="icon" type="image/png" sizes="192x192" href="{src size=192x192 type=png}">
+<link rel="icon" type="image/png" sizes="256x256" href="{src size=256x256 type=png}">
+<link rel="icon" type="image/png" sizes="384x384" href="{src size=384x384 type=png}">
+<link rel="icon" type="image/png" sizes="512x512" href="{src size=512x512 type=png}">
+<meta name="msapplication-square70x70logo" content="{src size=70x70 type=png}" />
+<meta name="msapplication-square150x150logo" content="{src size=150x150 type=png}" />
+<meta name="msapplication-wide310x150logo" content="{src size=310x150 type=png}" />
+<meta name="msapplication-square310x310logo" content="{src size=310x310 type=png}" />
+<meta name="msapplication-config" content="none"/>
+<meta name="msapplication-TileColor" content="#da532c" />
+<meta name="theme-color" content="#ffffff">]]></value>
     </configuration>
   </entities>
 </entity_configuration>


### PR DESCRIPTION
Adds a favicon template editor, which reduces the source images to just one which gets automatically resized according to the tags chosen:
![faviconconfig](https://user-images.githubusercontent.com/6775736/35022555-cc457df0-fb36-11e7-8785-cfcb878e954c.png)
