### PR TITLE
Fix for keywords disapear from search index

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4463,12 +4463,18 @@ class ProductCore extends ObjectModel
     public function deleteSearchIndexes()
     {
         return (
-        Db::getInstance()->execute(
-            'DELETE `'._DB_PREFIX_.'search_index`, `'._DB_PREFIX_.'search_word`
-				FROM `'._DB_PREFIX_.'search_index` JOIN `'._DB_PREFIX_.'search_word`
-				WHERE `'._DB_PREFIX_.'search_index`.`id_product` = '.(int) $this->id.'
-						AND `'._DB_PREFIX_.'search_word`.`id_word` = `'._DB_PREFIX_.'search_index`.id_word'
-        )
+            Db::getInstance()->execute(
+                'DELETE FROM `'._DB_PREFIX_.'search_index`
+                    WHERE `id_product` = '.(int)$this->id
+            )
+            &&
+            Db::getInstance()->execute(
+                'DELETE FROM `'._DB_PREFIX_.'search_word`
+                    WHERE `id_word` NOT IN (
+                        SELECT id_word
+                        FROM `'._DB_PREFIX_.'search_index`
+                    )'
+            )
         );
     }
 


### PR DESCRIPTION
Delete a product, and you delete words that is shared in search_word table, make other product disappear from search until next full reindex.