### PR TITLE
Fix PrestaShopDatabaseException in Tab

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -859,7 +859,7 @@ class TabCore extends ObjectModel
         && Db::getInstance()->update(
             'tab',
             [
-                '`position`' => (int) $position,
+                'position' => (int) $position,
             ],
             '`id_parent` = '.(int) $movedTab['id_parent'].' AND `id_tab`='.(int) $movedTab['id_tab']
         ));


### PR DESCRIPTION
The backquotes in 'position' field name in Tab::updatePosition() lead to incorrect SQL syntax further.
There is no backqutotes in field name above on https://github.com/thirtybees/thirtybees/blob/3724d25bb28c38cf5462806a85a8993fd06779b5/classes/Tab.php#L855

Also please check similar on https://github.com/thirtybees/thirtybees/blob/3724d25bb28c38cf5462806a85a8993fd06779b5/classes/AttributeGroup.php#L380