### PR TITLE
Pass the Cart object in the `actionCartSave` hook

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2725,7 +2725,7 @@ class CartCore extends ObjectModel
 
         $this->_products = null;
         $return = parent::update($nullValues);
-        Hook::exec('actionCartSave');
+        Hook::exec('actionCartSave', ['cart' => $this);
 
         return $return;
     }
@@ -4452,7 +4452,7 @@ class CartCore extends ObjectModel
         }
 
         $return = parent::add($autoDate, $nullValues);
-        Hook::exec('actionCartSave');
+        Hook::exec('actionCartSave', ['cart' => $this]);
 
         return $return;
     }


### PR DESCRIPTION
Because we don't have access to it when it has yet to be attached to the `Context` object.