### PR TITLE
fix issue #463 - can't register admin tabs when only one permission profile exists

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -623,17 +623,6 @@ class TabCore extends ObjectModel
             return false;
         }
 
-        /* Profile selection */
-        $profiles = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
-            (new DbQuery())
-                ->select('`id_profile`')
-                ->from('profile')
-                ->where('`id_profile` != 1')
-        );
-        if (!$profiles) {
-            return false;
-        }
-
         /* Query definition */
         $replace = [];
         $replace[] = [
@@ -644,6 +633,14 @@ class TabCore extends ObjectModel
             'edit'       => 1,
             'delete'     => 1,
         ];
+
+        /* Profile selection */
+        $profiles = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            (new DbQuery())
+                ->select('`id_profile`')
+                ->from('profile')
+                ->where('`id_profile` != 1')
+        );
         foreach ($profiles as $profile) {
             $rights = $profile['id_profile'] == $context->employee->id_profile ? 1 : 0;
             $replace[] = [


### PR DESCRIPTION
When there is only one permission profile (SA), then $profiles will be empty array, and
```
 if (!$profiles) {
   return false;        
 }
```
will evaluates to true. That's probably not what was the intention.  

The fix is simple - just get rid of whole condition.
