### PR TITLE
Fix hreflang tag

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -489,7 +489,7 @@ class FrontControllerCore extends Controller
                 $lnk .= "?p=$p";
             }
 
-            $links[] = '<link rel="alternate" href="'.$lnk.'" hreflang="'.$lang['iso_code'].'">';
+            $links[] = '<link rel="alternate" href="'.$lnk.'" hreflang="'.$lang['language_code'].'">';
             if ($lang['id_lang'] == $idLangDefault) {
                 $links[] = '<link rel="alternate" href="'.$lnk.'" hreflang="x-default">';
             }


### PR DESCRIPTION
The hreflang tag should contain a language code, not iso code.
Iso code is incorrect, cause for example it would give a "gb" language which doesn't exist in the ISO spec. On the other hand using the language code would give us a "en-gb" value.