### PR TITLE
php 7.2 support.

### DIFF
--- a/admin-dev/themes/default/template/controllers/information/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/information/helpers/view/view.tpl
@@ -93,7 +93,7 @@
 					<i class="icon-info"></i>
 					{l s='Server information'}
 				</h3>
-				{if count($uname)}
+				{if $uname}
 				<p>
 					<strong>{l s='Server information:'}</strong> {$uname|escape:'html':'UTF-8'}
 				</p>


### PR DESCRIPTION
in PHP 7.2
````count(): Parameter must be an array or an object that implements Countable````

uname param always return a string:
````https://github.com/thirtybees/thirtybees/blob/1.0.x/controllers/admin/AdminInformationController.php#L115````