### PR TITLE
Ensure RewriteCond for shop domain is always present

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3288,21 +3288,15 @@ class ToolsCore
                 if ($uri['virtual']) {
                     if (!$rewrite_settings) {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.trim($uri['virtual'], '/').'/?$ '.$uri['physical'].$uri['virtual']."index.php [L,R]\n");
                     } else {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.trim($uri['virtual'], '/').'$ '.$uri['physical'].$uri['virtual']." [L,R]\n");
                     }
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^'.ltrim($uri['virtual'], '/').'(.*) '.$uri['physical']."$1 [L]\n\n");
                 }
 
@@ -3311,15 +3305,11 @@ class ToolsCore
                     fwrite($write_fd, "# Images\n");
                     if (Configuration::get('PS_LEGACY_IMAGES')) {
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4.jpg [L]'."\n");
                         fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.webp %{ENV:REWRITEBASE}img/p/$1-$2$3$4.webp [L]'."\n");
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3.jpg [L]'."\n");
                         fwrite($write_fd, 'RewriteRule ^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.webp %{ENV:REWRITEBASE}img/p/$1-$2$3.webp [L]'."\n");
                     }
@@ -3333,22 +3323,16 @@ class ToolsCore
                         }
                         $img_name .= '$'.$j;
                         fwrite($write_fd, $media_domains);
-                        if (Shop::isFeatureActive()) {
-                            fwrite($write_fd, $domain_rewrite_cond);
-                        }
+                        fwrite($write_fd, $domain_rewrite_cond);
                         fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).".jpg [L]\n");
                         fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.webp %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).".webp [L]\n");
                     }
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3.jpg [L]'."\n");
                     fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.webp %{ENV:REWRITEBASE}img/c/$1$2$3.webp [L]'."\n");
                     fwrite($write_fd, $media_domains);
-                    if (Shop::isFeatureActive()) {
-                        fwrite($write_fd, $domain_rewrite_cond);
-                    }
+                    fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2.jpg [L]'."\n");
                     fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.webp %{ENV:REWRITEBASE}img/c/$1$2.webp [L]'."\n");
                 }


### PR DESCRIPTION
## Description 
When "Friendly URLs" are enabled together with Media Servers, there's a race condition where it will result in 404 for images either on the Media Server URL or the actual shop URL. 
The issue is caused by wrong rewrite rules and the lack of a rewrite rule matching the shop domain. The bug isn't directly apparent on Apache 2.4.x servers because Apache silently "fixes" the rules (RewriteCond ending with [OR] without a following RewriteCond). The fix is to include the shop domain.

## How to test

- Setup a shop on a Litespeed (apache compatible, except it doesn't contain a mod_rewrite bug)
- Enable a media server (such as `cdn.domain.com`)
- access an image on the shop URL such as `http://domain.com/thirtybees/3-home_default/soap.jpg` - this should work fine with my fixes as well

## Why this change should be implemented

Thirtybees should be compatible with Apache and Litespeed (a lot of shared hosts use this), the fact that current implementation has worked in Apache so far is simply due to a bug in the mod_rewrite engine by ignoring `RewriteCond` rules ending with `[OR]` when there has been no proceeding `RewriteCond`.

It also makes no sense to not include the shop URL in the RewriteCond, you'd want your images to be accessible on your media servers and on your shop URL at all times - the original code in reality shouldn't allow that.

The change is backwards-compatible and is a non-breaking change.

The benefit is that it will actually allow users of Litespeed to utilize friendly URL's and media servers at same time if these media servers happen to be a CDN it's where most people will see breakage.

The same bug has been submitted to Prestashop 1.6 and 1.7 - and it's in the process of getting merged into a bugfix release.

Since we have thirtybees users, we'd like the fix to exist in Thirtybees as well, thus I'm creating this PR to you guys.

If you have any questions or concerns, I'm always happy to answer them 👍 