### PR TITLE
Fix deserialization of cache keys. Closes #551

### DIFF
--- a/classes/cache/CacheFs.php
+++ b/classes/cache/CacheFs.php
@@ -54,7 +54,7 @@ class CacheFsCore extends Cache
 
         $keysFilename = $this->getFilename(static::KEYS_NAME);
         if (@filemtime($keysFilename)) {
-            $this->keys = json_decode(file_get_contents($keysFilename));
+            $this->keys = json_decode(file_get_contents($keysFilename), true);
         }
     }
 


### PR DESCRIPTION
This is another victim of serialize -> json_encode conversion, specifically commit 7bc4831.

line 57: $this->keys = json_decode(file_get_contents($keysFilename));

json_decode by default returns stdClass, but cache keys are expected to be associated array.

