### PR TITLE
Suggestion solution for failing SIRET and APE codes out of France

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1540,6 +1540,10 @@ class ValidateCore
      */
     public static function isSiret($siret)
     {
+        if (empty($siret) || (isset($siret) && $siret[0] == '-')) 
+        { 
+            return true; 
+        }
         if (mb_strlen($siret) != 14) {
             return false;
         }
@@ -1567,6 +1571,9 @@ class ValidateCore
      */
     public static function isApe($ape)
     {
+        if (empty($ape) || (isset($ape) && $ape[0] == '-')) { 
+            return true; 
+        }
         return (bool) preg_match('/^[0-9]{3,4}[a-zA-Z]{1}$/s', $ape);
     }
 

--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -637,11 +637,14 @@ class AdminCustomersControllerCore extends AdminController
                 'type'  => 'text',
                 'label' => $this->l('SIRET'),
                 'name'  => 'siret',
+				'hint'  => $this->l('To skip validation, add a dash at the beginning of the SIRET code'),
             ];
+
             $this->fields_form['input'][] = [
                 'type'  => 'text',
                 'label' => $this->l('APE'),
                 'name'  => 'ape',
+				'hint'  => $this->l('To skip validation, add a dash at the beginning of the APE code'),
             ];
             $this->fields_form['input'][] = [
                 'type'  => 'text',


### PR DESCRIPTION
Suggested solution for: https://github.com/thirtybees/thirtybees/issues/587
User needs to add a dash at the beginning of the strings to skip validation or simply enter empty string.