### PR TITLE
Avoid unnecessary DB query on users' password check.

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -420,9 +420,9 @@ class EmployeeCore extends ObjectModel
     }
 
     /**
-     * Return employee instance from its e-mail (optionnaly check password)
+     * Return employee instance from its e-mail (optionally check password)
      *
-     * @param string $email             e-mail
+     * @param string $email             E-mail
      * @param string $plainTextPassword Password is also checked if specified
      * @param bool   $activeOnly        Filter employee by active status
      *
@@ -435,8 +435,7 @@ class EmployeeCore extends ObjectModel
      */
     public function getByEmail($email, $plainTextPassword = null, $activeOnly = true)
     {
-        if (!Validate::isEmail($email)
-            || ($plainTextPassword && !Validate::isPasswdAdmin($plainTextPassword))) {
+        if (!Validate::isEmail($email) || ($plainTextPassword && !Validate::isPasswdAdmin($plainTextPassword))) {
             return false;
         }
 
@@ -447,20 +446,16 @@ class EmployeeCore extends ObjectModel
         if ($activeOnly) {
             $sql->where('`active` = 1');
         }
-
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
-        if ($plainTextPassword && !password_verify($plainTextPassword, $result['passwd'])) {
-            $sql = new DbQuery();
-            $sql->select('*');
-            $sql->from('employee');
-            $sql->where('`email` = \''.pSQL($email).'\'');
-            $sql->where('`passwd` = \''.md5(_COOKIE_KEY_.$plainTextPassword).'\'');
-            if ($activeOnly) {
-                $sql->where('`active` = 1');
-            }
 
-            $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
-            if ($result) {
+        if (!$result) {
+            return false;
+        }
+
+        // If password is provided but doesn't match.
+        if ($plainTextPassword && !password_verify($plainTextPassword, $result['passwd'])) {
+            // Check if it matches the legacy md5 hashing and, if it does, rehash it.
+            if (Validate::isMd5($result['passwd']) && $result['passwd'] === md5(_COOKIE_KEY_.$plainTextPassword)) {
                 $newHash = Tools::hash($plainTextPassword);
                 Db::getInstance()->update(
                     bqSQL(static::$definition['table']),
@@ -473,10 +468,6 @@ class EmployeeCore extends ObjectModel
             } else {
                 return false;
             }
-        }
-
-        if (!$result) {
-            return false;
         }
 
         $this->id = $result['id_employee'];


### PR DESCRIPTION
When a user login attempt fails, avoid an unnecessary database query.

Also check that the user-sent password is a valid md5 hash before trying to hash and check it.