### PR TITLE
Couple of fixes to make smarty run on php 7.2

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -457,7 +457,7 @@ class AddressFormatCore extends ObjectModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function generateAddressSmarty($params, &$smarty)
+    public static function generateAddressSmarty($params, $smarty)
     {
         return AddressFormat::generateAddress(
             $params['address'],

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -560,7 +560,7 @@ class ImageCore extends ObjectModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function getWidth($params, &$smarty)
+    public static function getWidth($params, $smarty)
     {
         $result = static::getSize($params['type']);
 
@@ -602,7 +602,7 @@ class ImageCore extends ObjectModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function getHeight($params, &$smarty)
+    public static function getHeight($params, $smarty)
     {
         $result = static::getSize($params['type']);
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2399,7 +2399,7 @@ class ProductCore extends ObjectModel
      * @version 1.0.0 Initial version
      * @throws PrestaShopException
      */
-    public static function convertPrice($params, &$smarty)
+    public static function convertPrice($params, $smarty)
     {
         return Tools::displayPrice($params['price'], Context::getContext()->currency);
     }
@@ -2416,7 +2416,7 @@ class ProductCore extends ObjectModel
      * @version 1.0.0 Initial version
      * @throws PrestaShopException
      */
-    public static function convertPriceWithCurrency($params, &$smarty)
+    public static function convertPriceWithCurrency($params, $smarty)
     {
         return Tools::displayPrice($params['price'], $params['currency'], false);
     }
@@ -2431,7 +2431,7 @@ class ProductCore extends ObjectModel
      * @version 1.0.0 Initial version
      * @throws PrestaShopException
      */
-    public static function displayWtPrice($params, &$smarty)
+    public static function displayWtPrice($params, $smarty)
     {
         return Tools::displayPrice($params['p'], Context::getContext()->currency);
     }
@@ -2448,7 +2448,7 @@ class ProductCore extends ObjectModel
      * @version 1.0.0 Initial version
      * @throws PrestaShopException
      */
-    public static function displayWtPriceWithCurrency($params, &$smarty)
+    public static function displayWtPriceWithCurrency($params, $smarty)
     {
         return Tools::displayPrice($params['price'], $params['currency'], false);
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -762,7 +762,7 @@ class ToolsCore
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function displayPriceSmarty($params, &$smarty)
+    public static function displayPriceSmarty($params, $smarty)
     {
         if (array_key_exists('currency', $params)) {
             $currency = Currency::getCurrencyInstance((int) $params['currency']);
@@ -1244,7 +1244,7 @@ class ToolsCore
      * @version 1.0.0 Initial version
      * @throws PrestaShopException
      */
-    public static function dateFormat($params, &$smarty)
+    public static function dateFormat($params, $smarty)
     {
         return Tools::displayDate($params['date'], null, (isset($params['full']) ? $params['full'] : false));
     }
@@ -1707,7 +1707,7 @@ class ToolsCore
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function getAdminTokenLiteSmarty($params, &$smarty)
+    public static function getAdminTokenLiteSmarty($params, $smarty)
     {
         $context = Context::getContext();
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -177,16 +177,12 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
     }
 
     // lazy is better if the function is not called on every page
-    if ($lazy) {
+    if ($lazy && is_array($params)) {
         $lazy_register = SmartyLazyRegister::getInstance();
         $lazy_register->register($params);
 
-        if (is_array($params)) {
-            $params = $params[1];
-        }
-
         // SmartyLazyRegister allows to only load external class when they are needed
-        $smarty->registerPlugin($type, $function, [$lazy_register, $params]);
+        $smarty->registerPlugin($type, $function, [$lazy_register, $params[1]]);
     } else {
         $smarty->registerPlugin($type, $function, $params);
     }

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -256,23 +256,15 @@ class SmartyLazyRegister
     public function __call($name, $arguments)
     {
         $item = $this->registry[$name];
-
-        // case 1: call to static method - case 2 : call to static function
-        if (is_array($item[1])) {
-            return call_user_func_array($item[1].'::'.$item[0], [$arguments[0], &$arguments[1]]);
-        } else {
-            $args = [];
-
-            foreach ($arguments as $a => $argument) {
-                if ($a == 0) {
-                    $args[] = $arguments[0];
-                } else {
-                    $args[] = &$arguments[$a];
-                }
+        $args = [];
+        foreach ($arguments as $a => $argument) {
+            if ($a == 0) {
+                $args[] = $arguments[0];
+            } else {
+                $args[] = &$arguments[$a];
             }
-
-            return call_user_func_array($item, $args);
         }
+        return call_user_func_array($item, $args);
     }
 
     public static function getInstance()

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -88,17 +88,17 @@ smartyRegisterFunction($smarty, 'function', 'implode', array('Tools', 'smartyImp
 smartyRegisterFunction($smarty, 'modifier', 'utf8ToIdn', array('Tools', 'convertEmailToIdn'));
 smartyRegisterFunction($smarty, 'modifier', 'idnToUtf8', array('Tools', 'convertEmailFromIdn'));
 
-function smartyDieObject($params, &$smarty)
+function smartyDieObject($params, $smarty)
 {
     return Tools::d($params['var']);
 }
 
-function smartyShowObject($params, &$smarty)
+function smartyShowObject($params, $smarty)
 {
     return Tools::p($params['var']);
 }
 
-function smartyMaxWords($params, &$smarty)
+function smartyMaxWords($params, $smarty)
 {
     Tools::displayAsDeprecated();
     $params['s'] = str_replace('...', ' ...', html_entity_decode($params['s'], ENT_QUOTES, 'UTF-8'));
@@ -113,7 +113,7 @@ function smartyMaxWords($params, &$smarty)
     return implode(' ',  Tools::htmlentitiesUTF8($words));
 }
 
-function smartyTruncate($params, &$smarty)
+function smartyTruncate($params, $smarty)
 {
     Tools::displayAsDeprecated();
     $text = isset($params['strip']) ? strip_tags($params['text']) : $params['text'];
@@ -150,7 +150,7 @@ function smarty_modifier_htmlentitiesUTF8($string)
 {
     return Tools::htmlentitiesUTF8($string);
 }
-function smartyMinifyHTML($tpl_output, &$smarty)
+function smartyMinifyHTML($tpl_output, $smarty)
 {
     $context = Context::getContext();
     if (isset($context->controller) && in_array($context->controller->php_self, ['pdf-invoice', 'pdf-order-return', 'pdf-order-slip'])) {
@@ -160,7 +160,7 @@ function smartyMinifyHTML($tpl_output, &$smarty)
     return $tpl_output;
 }
 
-function smartyPackJSinHTML($tpl_output, &$smarty)
+function smartyPackJSinHTML($tpl_output, $smarty)
 {
     $context = Context::getContext();
     if (isset($context->controller) && in_array($context->controller->php_self, ['pdf-invoice', 'pdf-order-return', 'pdf-order-slip'])) {
@@ -189,7 +189,7 @@ function smartyRegisterFunction($smarty, $type, $function, $params, $lazy = true
     }
 }
 
-function smartyHook($params, &$smarty)
+function smartyHook($params, $smarty)
 {
     if (!empty($params['h'])) {
         $id_module = null;
@@ -217,7 +217,7 @@ function smartyCleanHtml($data)
     }
 }
 
-function toolsConvertPrice($params, &$smarty)
+function toolsConvertPrice($params, $smarty)
 {
     return Tools::convertPrice($params['price'], Context::getContext()->currency);
 }

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -38,7 +38,7 @@ $smarty->force_compile = (Configuration::get('PS_SMARTY_FORCE_COMPILE') == _PS_S
 // But force compile_check since the performance impact is small and it is better for debugging
 $smarty->compile_check = true;
 
-function smartyTranslate($params, &$smarty)
+function smartyTranslate($params, $smarty)
 {
     $htmlentities = !isset($params['js']);
     $pdf = isset($params['pdf']);

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -36,7 +36,7 @@ if (Configuration::get('PS_JS_HTML_THEME_COMPRESSION')) {
     $smarty->registerFilter('output', 'smartyPackJSinHTML');
 }
 
-function smartyTranslate($params, &$smarty)
+function smartyTranslate($params, $smarty)
 {
     global $_LANG;
 


### PR DESCRIPTION
I'm creating this pull request just for review purpose. @Traumflug could you please review the changes?

Summary of what's being fixed:

When we run on php 7.2 (and update smarty to newer version), we immediately get this fatal error:

`Parameter 2 to smartyTranslate() expected to be a reference, value given`

### The problem is this:
- `smartyTranslate` function [signature](https://github.com/thirtybees/thirtybees/blob/b37b394a0dc6790f3771d642357fb982d2feaf04/config/smartyfront.config.inc.php#L39) expects `$smarty` parameter to be passed as reference, but smarty engine is passing it as normal value.
- `smartyTranslate` function is not [lazy registered](https://github.com/thirtybees/thirtybees/blob/b37b394a0dc6790f3771d642357fb982d2feaf04/config/smarty.config.inc.php#L67). If it was, this error would not appear, because of a bug in lazy loader that actually passes the parameters [by reference](https://github.com/thirtybees/thirtybees/blob/b37b394a0dc6790f3771d642357fb982d2feaf04/config/smarty.config.inc.php#L270)

### Fix
1. fix SmartyLazyRegister, so it do not pass parameter as reference
2. replace all `&$smarty` in the callbacks by simple `$smarty`

This makes all plugin callbacks usable directly by smarty, or indirectly via SmartyLazyRegister. For more info, read comments on individual commits
