### PR TITLE
CO : Error when post_max_size is 0

### DIFF
--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -284,6 +284,10 @@ class UploaderCore
     public function getPostMaxSizeBytes()
     {
         $postMaxSize = ini_get('post_max_size');
+        if (!$post_max_size) {
+            return static::DEFAULT_MAX_SIZE;
+        }
+        
         $bytes = (int) trim($postMaxSize);
         $last = strtolower($postMaxSize[strlen($postMaxSize) - 1]);
 

--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -284,7 +284,7 @@ class UploaderCore
     public function getPostMaxSizeBytes()
     {
         $postMaxSize = ini_get('post_max_size');
-        if (!$post_max_size) {
+        if (!$postMaxSize) {
             return static::DEFAULT_MAX_SIZE;
         }
         


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If you configure `post_max_size = 0` in php.ini and try to edit a product, there's a JS error in files `admin/themes/default/template/controllers/products/helpers/uploader/attachment_ajax.tpl` and `admin/themes/default/template/controllers/products/helpers/uploader/ajax.tpl` because variable `$post_max_size` is empty.
| Type?         | bug fix
| Category?     | CO 
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Set `post_max_size = 0` in php.ini. Try to edit a product.