### PR TITLE
Fix TB_CUSTOMCODE_METAS was not actually saved

### DIFF
--- a/controllers/admin/AdminCustomCodeController.php
+++ b/controllers/admin/AdminCustomCodeController.php
@@ -113,8 +113,7 @@ class AdminCustomCodeControllerCore extends AdminController
         }
         $called = true;
 
-        $safeMetas = strip_tags(Tools::getValue(Configuration::CUSTOMCODE_METAS), '<meta>');
-        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_METAS, $safeMetas, true);
+        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_METAS, Tools::getValue(Configuration::CUSTOMCODE_METAS), true);
     }
 
     /**
@@ -150,7 +149,7 @@ class AdminCustomCodeControllerCore extends AdminController
         }
         $called = true;
 
-        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_ORDERCONF_JS, Tools::getValue(Configuration::CUSTOMCODE_ORDERCONF_JS));
+        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_ORDERCONF_JS, Tools::getValue(Configuration::CUSTOMCODE_ORDERCONF_JS), true);
     }
 
     /**

--- a/controllers/admin/AdminCustomCodeController.php
+++ b/controllers/admin/AdminCustomCodeController.php
@@ -167,7 +167,7 @@ class AdminCustomCodeControllerCore extends AdminController
         }
         $called = true;
 
-        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_JS, Tools::getValue(Configuration::CUSTOMCODE_JS));
+        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_JS, Tools::getValue(Configuration::CUSTOMCODE_JS), true);
     }
 
     /**

--- a/controllers/admin/AdminCustomCodeController.php
+++ b/controllers/admin/AdminCustomCodeController.php
@@ -173,11 +173,12 @@ class AdminCustomCodeControllerCore extends AdminController
     /**
      * @param string $key
      * @param string $value
+     * @param bool   $htmlOK
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    protected function updateOptionUnescaped($key, $value)
+    protected function updateOptionUnescaped($key, $value, $htmlOK = false)
     {
         if (Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             (new DbQuery())
@@ -188,7 +189,7 @@ class AdminCustomCodeControllerCore extends AdminController
             Db::getInstance()->update(
                 bqSQL(Configuration::$definition['table']),
                 [
-                    'value'    => pSQL($value),
+                    'value'    => pSQL($value, $htmlOK),
                     'date_upd' => ['type' => 'sql', 'value' => 'NOW()'],
                 ],
                 '`id_shop` IS NULL AND `id_shop_group` IS NULL AND `name` = \''.pSQL($key).'\'',
@@ -200,7 +201,7 @@ class AdminCustomCodeControllerCore extends AdminController
                 bqSQL(Configuration::$definition['table']),
                 [
                     'name'          => pSQL($key),
-                    'value'         => pSQL($value),
+                    'value'         => pSQL($value, $htmlOK),
                     'id_shop'       => null,
                     'id_shop_group' => null,
                     'date_add'      => ['type' => 'sql', 'value' => 'NOW()'],
@@ -221,7 +222,7 @@ class AdminCustomCodeControllerCore extends AdminController
                 Db::getInstance()->update(
                     bqSQL(Configuration::$definition['table']),
                     [
-                        'value'    => pSQL($value),
+                        'value'    => pSQL($value, $htmlOK),
                         'date_upd' => ['type' => 'sql', 'value' => 'NOW()'],
                     ],
                     '`id_shop` = '.(int) $idShop.' AND `id_shop_group` = '.$idShopGroup.' AND `name` = \''.pSQL($key).'\'',
@@ -233,7 +234,7 @@ class AdminCustomCodeControllerCore extends AdminController
                     bqSQL(Configuration::$definition['table']),
                     [
                         'name'          => pSQL($key),
-                        'value'         => pSQL($value),
+                        'value'         => pSQL($value, $htmlOK),
                         'id_shop'       => $idShop,
                         'id_shop_group' => $idShopGroup,
                         'date_add'      => ['type' => 'sql', 'value' => 'NOW()'],

--- a/controllers/admin/AdminCustomCodeController.php
+++ b/controllers/admin/AdminCustomCodeController.php
@@ -113,7 +113,8 @@ class AdminCustomCodeControllerCore extends AdminController
         }
         $called = true;
 
-        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_METAS, Tools::getValue(Configuration::CUSTOMCODE_METAS));
+        $safeMetas = strip_tags(Tools::getValue(Configuration::CUSTOMCODE_METAS), '<meta>');
+        $this->updateOptionUnescaped(Configuration::CUSTOMCODE_METAS, $safeMetas, true);
     }
 
     /**

--- a/controllers/admin/AdminCustomCodeController.php
+++ b/controllers/admin/AdminCustomCodeController.php
@@ -181,6 +181,10 @@ class AdminCustomCodeControllerCore extends AdminController
      */
     protected function updateOptionUnescaped($key, $value, $htmlOK = false)
     {
+        if(!$htmlOK) {
+            $value = strip_tags($value);
+            $htmlOK = true;
+        }
         if (Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
             (new DbQuery())
                 ->select('`'.bqSQL(Configuration::$definition['primary']).'`')


### PR DESCRIPTION
Different sanitization between `pSQL()` and `Configuration::set()` make the situation where HTML (together with meta tags in _METAS) were removed prior to the value was updated in the database but kept on the page/editor as if it was saved. And so it is difficult to notice the loss on time.
So I decide also to move tags stripping prior to booth `pSQL()` and `Configuration::set()` while allowing meta tags.
And I see a similar thing in the `Configuration::updateValue()`.

Should other tags be allowed in _METAS in case of the info note on the page says about any HTML in `<head>`?

HTMLPurifier's love of breaking complex css (and possibly another) with `&gt;`/ `&lt;` along with the mentioned and independent tag cleaning (in `pSQL`) makes this warning a little inaccurate.
https://github.com/thirtybees/thirtybees/blob/076aaa5d56d4eb6d76b10aae3eda919f90973db6/controllers/admin/AdminCustomCodeController.php#L28

// Sorry for my English.