### PR TITLE
Update SpecificPriceRule.php

### DIFF
--- a/classes/SpecificPriceRule.php
+++ b/classes/SpecificPriceRule.php
@@ -203,7 +203,7 @@ class SpecificPriceRuleCore extends ObjectModel
             foreach ($conditionsGroup as $idConditionGroup => $conditionGroup) {
                 // Base request
                 $query = (new DbQuery())
-                    ->select('p.`id_product`')
+                    ->select('DISTINCT p.`id_product`')
                     ->from('product', 'p')
                     ->leftJoin('product_shop', 'ps', 'p.`id_product` = ps.`id_product`')
                     ->where('ps.id_shop = '.(int) $currentShopId)


### PR DESCRIPTION
Duplicate entry XXXXXX for key id_product_2 - INSERT INTO ps_specific_price - BackOffice, créer/éditer un produit
When there are catalog rules with category conditions, when you register a product, you experience this error.
The code involved is SpecificPriceRule.php SpecificPriceRule :: getAffectedProducts ()
source: https://aide.prestashop.click/topic/1071/1-6-1-0-duplicate-entry-xxxxxx-for-key-id_product_2-insert-into-ps_specific_price-backoffice-cr%C3%A9er-%C3%A9diter-un-produit-specificpricerule-php