### PR TITLE
Redirection to forced http after redirection domain (https)

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -370,7 +370,7 @@ class ShopCore extends ObjectModel
                         $redirectHeader = ($redirectType == 1 ? 'Found' : 'Moved Permanently');
                         header('HTTP/1.0 '.$redirectCode.' '.$redirectHeader);
                         header('Cache-Control: no-cache');
-                        header('Location: http://'.$url);
+                        header('Location: '.Tools::getShopProtocol().$url);
                         exit;
                     }
                 }
@@ -438,7 +438,7 @@ class ShopCore extends ObjectModel
                 $redirectCode = ($redirectType == 1 ? '302' : '301');
                 $redirectHeader = ($redirectType == 1 ? 'Found' : 'Moved Permanently');
                 header('HTTP/1.0 '.$redirectCode.' '.$redirectHeader);
-                header('Location: http://'.$url);
+                header('Location: '.Tools::getShopProtocol().$url);
                 exit;
             } elseif (defined('_PS_ADMIN_DIR_') && empty($shop->physical_uri)) {
                 $shopDefault = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));


### PR DESCRIPTION
When the user requests the shop by one of the non canonical domains (domain.tld vs www.domain.tld),
PrestaShop causes a redirection to the http: //www.domain.tld.
This leads to a cascade of redirects. https: //domain.tld => http: //www.domain.tld => https: //www.domain.tld

source : https://aide.prestashop.click/topic/1068/1-5-0-17-redirection-vers-http-forc%C3%A9e-suite-%C3%A0-redirection-shop-domain-en-https