### PR TITLE
BO: Combination dropdown visibility

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -501,6 +501,8 @@ $(document).ready(function() {
 			callback: function(text) { combinable_filter('#cart_rule_select_2', text, 'selected'); }
 		});
 	}
+	
+	displayProductAttributes();
 });
 
 


### PR DESCRIPTION
When you load a cart rule with a gift product and the gift product search found more than 1 product, all the combination dropdowns are visible.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Only the product's combination dropdown is displayed
| How to test?  | Create a product with name and reference "AAA" with 2 combinations. Create a product with name and reference "AAAA" with 2 combinations. Create a cart rule with "AAA" as gift product. Save the rule. Load the rule and you will see 2 dropdowns, one with "AAA" combinations and another with "AAAA" combinations.