### PR TITLE
Debug mode

### DIFF
--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2018 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @copyright 2017-2018 thirty bees
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+/**
+ * Class ErrorHandlerCore
+ *
+ * @since 1.0.9
+ */
+class ErrorHandlerCore
+{
+
+    /**
+     * @var ErrorHandlerCore singleton instance;
+     */
+    protected static $instance;
+
+    /**
+     * @var bool true if error handling has been set up
+     */
+    protected $initialized = false;
+
+    /**
+     * Get instance of error handler
+     *
+     * @return ErrorHandlerCore
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     */
+    public static function getInstance()
+    {
+        if (! static::$instance) {
+            static::$instance = new static();
+        }
+        return static::$instance;
+    }
+
+    /**
+     * Initialize error handling logic
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     * @throws PrestaShopException
+     */
+    public function init()
+    {
+        if ($this->initialized) {
+            throw new PrestaShopException("Error handler already initialized");
+        }
+        $this->initialized = true;
+    }
+
+}

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -255,7 +255,7 @@ class ErrorHandlerCore
      * @param $file
      * @return string file
      */
-    private static function normalizeFileName($file)
+    public static function normalizeFileName($file)
     {
         return ltrim(str_replace([_PS_ROOT_DIR_, '\\'], ['', '/'], $file), '/');
     }

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -56,6 +56,11 @@ class ErrorHandlerCore
     protected $preventDefaultErrorHandler = false;
 
     /**
+     * @var object psr compliant logger
+     */
+    protected $logger = null;
+
+    /**
      * Get instance of error handler
      *
      * @return ErrorHandlerCore
@@ -147,18 +152,91 @@ class ErrorHandlerCore
         // detect whether this message was
         $suppressed = error_reporting() === 0;
         $error = [
-
             'errno' => $errno,
             'errstr' => $errstr,
             'errfile' => $errfile,
             'errline' => $errline,
             'suppressed' => $suppressed,
-            'type' => static::getErrorType($errno)
+            'type' => static::getErrorType($errno),
+            'level' => static::getLogLevel($errno)
         ];
         $this->errorMessages[] = $error;
+        if (! $suppressed) {
+            $this->logMessage($error);
+        }
 
         return $suppressed || $this->preventDefaultErrorHandler;
     }
+
+    /**
+     * Sets external logger. If $replay parameter is true, then any already collected error messages will be
+     * emitted
+     *
+     * @param $logger
+     * @param bool $replay
+     */
+    public function setLogger(LoggerInterface $logger, $replay=false)
+    {
+        $this->logger = $logger;
+        if ($replay) {
+            forEach($this->getErrorMessages(false) as $errorMessage) {
+                $this->logMessage($errorMessage);
+            }
+        }
+    }
+
+    /**
+     * Forward error message to psr compliant logger
+     *
+     * @param $msg
+     */
+    protected function logMessage($msg)
+    {
+        if (! $this->logger) {
+            return;
+        }
+
+        $file = static::normalizeFileName($msg['errfile']);
+        $message = $msg['type'] . ': ' . $msg['errstr'] . ' in ' . $file . ' at line ' . $msg['errline'];
+        switch ($msg['level']) {
+            case LogLevel::EMERGENCY:
+                $this->logger->emergency($message);
+                break;
+            case LogLevel::ALERT:
+                $this->logger->alert($message);
+                break;
+            case LogLevel::CRITICAL:
+                $this->logger->critical($message);
+                break;
+            case LogLevel::ERROR:
+                $this->logger->error($message);
+                break;
+            case LogLevel::WARNING:
+                $this->logger->warning($message);
+                break;
+            case LogLevel::NOTICE:
+                $this->logger->notice($message);
+                break;
+            case LogLevel::INFO:
+                $this->logger->info($message);
+                break;
+            case LogLevel::DEBUG:
+                $this->logger->debug($message);
+                break;
+        }
+    }
+
+    /**
+     * Returns file name relative to thirtybees root directory
+     *
+     * @param $file
+     * @return string file
+     */
+    private static function normalizeFileName($file)
+    {
+        return ltrim(str_replace([_PS_ROOT_DIR_, '\\'], ['', '/'], $file), '/');
+    }
+
 
     /**
      * Returns error type for given error level
@@ -187,6 +265,35 @@ class ErrorHandlerCore
                 return 'Deprecation';
             default:
                 return 'Unknown error';
+        }
+    }
+
+    /**
+     * Returns error PSR log level for given error level
+     *
+     * @param int $errno level of the error raised
+     *
+     * @return string error log level
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     */
+    public static function getLogLevel($errno)
+    {
+        switch ($errno) {
+            case E_USER_ERROR:
+            case E_ERROR:
+                return 'error';
+            case E_USER_WARNING:
+            case E_WARNING:
+            case E_USER_DEPRECATED:
+            case E_DEPRECATED:
+                return 'warning';
+            case E_USER_NOTICE:
+            case E_NOTICE:
+                return 'notice';
+            default:
+                return 'warning';
         }
     }
 

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -46,6 +46,16 @@ class ErrorHandlerCore
     protected $initialized = false;
 
     /**
+     * @var array list of errors, warnings and notices encountered during request processing
+     */
+    protected $errorMessages = [];
+
+    /**
+     * @var bool indicates, whether we should prevent default error handler or not
+     */
+    protected $preventDefaultErrorHandler = false;
+
+    /**
      * Get instance of error handler
      *
      * @return ErrorHandlerCore
@@ -74,10 +84,34 @@ class ErrorHandlerCore
             throw new PrestaShopException("Error handler already initialized");
         }
 
-        /* Set uncaught exception handler */
+        @ini_set('display_errors', 'off');
+        @error_reporting(E_ALL | E_STRICT);
+
+        // if we can't turn off display errors, we have to prevent default error handler instead
+        $this->preventDefaultErrorHandler = @ini_get('display_errors') !== 'off';
+
+        // Set uncaught exception handler
         set_exception_handler([$this, 'uncaughtExceptionHandler']);
 
+        // Set error handler
+        set_error_handler([$this, 'errorHandler']);
+
+
+
         $this->initialized = true;
+    }
+
+    /**
+     * @return array of collected error messages
+     */
+    public function getErrorMessages($includeSuppressed = false)
+    {
+        if ($this->errorMessages) {
+            return $includeSuppressed ? $this->errorMessages : array_filter($this->errorMessages, function ($error) {
+                return !$error['suppressed'];
+            });
+        }
+        return [];
     }
 
     /**
@@ -91,6 +125,69 @@ class ErrorHandlerCore
     {
         $exception = new PrestaShopException($e->getMessage(), $e->getCode(), null, $e->getTrace(), $e->getFile(), $e->getLine());
         $exception->displayMessage();
+    }
+
+
+    /**
+     * Error handler. It only records any error, warning or notice to $errors array
+     * and yields to default handler
+     *
+     * @param int $errno level of the error raised
+     * @param string $errstr error message
+     * @param string $errfile filename that the error was raised in
+     * @param int $errline line number the error was raised at
+     *
+     * @return bool
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     */
+    public function errorHandler($errno, $errstr, $errfile, $errline)
+    {
+        // detect whether this message was
+        $suppressed = error_reporting() === 0;
+        $error = [
+
+            'errno' => $errno,
+            'errstr' => $errstr,
+            'errfile' => $errfile,
+            'errline' => $errline,
+            'suppressed' => $suppressed,
+            'type' => static::getErrorType($errno)
+        ];
+        $this->errorMessages[] = $error;
+
+        return $suppressed || $this->preventDefaultErrorHandler;
+    }
+
+    /**
+     * Returns error type for given error level
+     *
+     * @param int $errno level of the error raised
+     *
+     * @return string error type
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     */
+    public static function getErrorType($errno)
+    {
+        switch ($errno) {
+            case E_USER_ERROR:
+            case E_ERROR:
+                return 'Fatal error';
+            case E_USER_WARNING:
+            case E_WARNING:
+                return 'Warning';
+            case E_USER_NOTICE:
+            case E_NOTICE:
+                return 'Notice';
+            case E_USER_DEPRECATED:
+            case E_DEPRECATED:
+                return 'Deprecation';
+            default:
+                return 'Unknown error';
+        }
     }
 
 }

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -207,8 +207,8 @@ class ErrorHandlerCore
             return;
         }
 
-        $file = static::normalizeFileName($msg['errfile']);
-        $message = $msg['type'] . ': ' . $msg['errstr'] . ' in ' . $file . ' at line ' . $msg['errline'];
+        $message = static::formatErrorMessage($msg);
+
         switch ($msg['level']) {
             case LogLevel::EMERGENCY:
                 $this->logger->emergency($message);
@@ -235,6 +235,18 @@ class ErrorHandlerCore
                 $this->logger->debug($message);
                 break;
         }
+    }
+
+    /**
+     * Converts $msg to string representation
+     *
+     * @param $msg array error message
+     * @return string
+     */
+    public static function formatErrorMessage($msg)
+    {
+        $file = static::normalizeFileName($msg['errfile']);
+        return $msg['type'] . ': ' . $msg['errstr'] . ' in ' . $file . ' at line ' . $msg['errline'];
     }
 
     /**

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -121,7 +121,7 @@ class ErrorHandlerCore
      * @version 1.0.9 Initial version
      * @param Exception $e uncaught exception
      */
-    public function uncaughtExceptionHandler(Exception $e)
+    public function uncaughtExceptionHandler(Throwable $e)
     {
         $exception = new PrestaShopException($e->getMessage(), $e->getCode(), null, $e->getTrace(), $e->getFile(), $e->getLine());
         $exception->displayMessage();

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -73,7 +73,24 @@ class ErrorHandlerCore
         if ($this->initialized) {
             throw new PrestaShopException("Error handler already initialized");
         }
+
+        /* Set uncaught exception handler */
+        set_exception_handler([$this, 'uncaughtExceptionHandler']);
+
         $this->initialized = true;
+    }
+
+    /**
+     * Uncaught exception handler - any uncaught exception will be processed by this method
+     *
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     * @param Exception $e uncaught exception
+     */
+    public function uncaughtExceptionHandler(Exception $e)
+    {
+        $exception = new PrestaShopException($e->getMessage(), $e->getCode(), null, $e->getTrace(), $e->getFile(), $e->getLine());
+        $exception->displayMessage();
     }
 
 }

--- a/classes/ErrorHandler.php
+++ b/classes/ErrorHandler.php
@@ -51,11 +51,6 @@ class ErrorHandlerCore
     protected $errorMessages = [];
 
     /**
-     * @var bool indicates, whether we should prevent default error handler or not
-     */
-    protected $preventDefaultErrorHandler = false;
-
-    /**
      * @var object psr compliant logger
      */
     protected $logger = null;
@@ -91,9 +86,6 @@ class ErrorHandlerCore
 
         @ini_set('display_errors', 'off');
         @error_reporting(E_ALL | E_STRICT);
-
-        // if we can't turn off display errors, we have to prevent default error handler instead
-        $this->preventDefaultErrorHandler = @ini_get('display_errors') !== 'off';
 
         // Set uncaught exception handler
         set_exception_handler([$this, 'uncaughtExceptionHandler']);
@@ -165,7 +157,7 @@ class ErrorHandlerCore
         if (! $suppressed) {
             $this->logMessage($error);
         }
-        return $suppressed || $this->preventDefaultErrorHandler;
+        return $suppressed || static::displayErrorEnabled();
     }
 
     /**
@@ -327,6 +319,31 @@ class ErrorHandlerCore
                 return 'notice';
             default:
                 return 'warning';
+        }
+    }
+
+
+    /**
+     * Returns true, if display_errors settings is turned on
+     * @since   1.0.9
+     * @version 1.0.9 Initial version
+     */
+    public static function displayErrorEnabled() {
+        $value = @ini_get('display_errors');
+        switch (strtolower($value)) {
+            case 'on':
+            case 'yes':
+            case 'true':
+            case 'stdout':
+            case 'stderr':
+            case '1':
+                return true;
+            case 'off':
+            case 'no':
+            case '0':
+                return false;
+            default:
+                return (bool)(int)$value;
         }
     }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2135,10 +2135,7 @@ class AdminControllerCore extends Controller
         }
 
         if (_PS_MODE_DEV_) {
-            $messages = ErrorHandler::getInstance()->getErrorMessages();
-            if ($messages) {
-                $this->context->smarty->assign('php_errors', $messages);
-            }
+            $this->assignErrorMessages();
         }
 
         $this->context->smarty->assign(
@@ -4716,4 +4713,17 @@ class AdminControllerCore extends Controller
 
         return $result;
     }
+
+    /**
+     * Retrieves collected error messages and assign them to
+     * smarty variable 'php_errors'
+     */
+    protected function assignErrorMessages()
+    {
+        $messages = ErrorHandler::getInstance()->getErrorMessages();
+        if ($messages) {
+            $this->context->smarty->assign('php_errors', $messages);
+        }
+    }
+
 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2134,6 +2134,13 @@ class AdminControllerCore extends Controller
             );
         }
 
+        if (_PS_MODE_DEV_) {
+            $messages = ErrorHandler::getInstance()->getErrorMessages();
+            if ($messages) {
+                $this->context->smarty->assign('php_errors', $messages);
+            }
+        }
+
         $this->context->smarty->assign(
             [
                 'page'   => $this->json ? json_encode($page) : $page,

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -37,8 +37,6 @@
 abstract class ControllerCore
 {
     // @codingStandardsIgnoreStart
-    /** @var array List of PHP errors */
-    public static $php_errors = [];
     /** @var array List of CSS files */
     public $css_files = [];
 
@@ -123,62 +121,6 @@ abstract class ControllerCore
     public static function getController($className, $auth = false, $ssl = false)
     {
         return new $className($auth, $ssl);
-    }
-
-    /**
-     * Custom error handler
-     *
-     * @param string $errno
-     * @param string $errstr
-     * @param string $errfile
-     * @param int    $errline
-     *
-     * @return bool
-     *
-     * @since   1.0.0
-     * @version 1.0.0 Initial version
-     */
-    public static function myErrorHandler($errno, $errstr, $errfile, $errline)
-    {
-        if (error_reporting() === 0) {
-            return false;
-        }
-
-        switch ($errno) {
-            case E_USER_ERROR:
-            case E_ERROR:
-                die('Fatal error: '.$errstr.' in '.$errfile.' on line '.$errline);
-                break;
-            case E_USER_WARNING:
-            case E_WARNING:
-                $type = 'Warning';
-                break;
-            case E_USER_NOTICE:
-            case E_NOTICE:
-                $type = 'Notice';
-                break;
-            case E_USER_DEPRECATED:
-            case E_DEPRECATED:
-                $type = 'Deprecation';
-                break;
-            default:
-                $type = 'Unknown error';
-                break;
-        }
-
-        // @codingStandardsIgnoreStart
-        static::$php_errors[] = [
-            'type'    => $type,
-            'errline' => (int) $errline,
-            'errfile' => str_replace('\\', '\\\\', $errfile), // Hack for Windows paths
-            'errno'   => (int) $errno,
-            'errstr'  => $errstr,
-        ];
-
-        Context::getContext()->smarty->assign('php_errors', static::$php_errors);
-        // @codingStandardsIgnoreEnd
-
-        return true;
     }
 
     /**
@@ -299,10 +241,6 @@ abstract class ControllerCore
      */
     public function init()
     {
-        if (_PS_MODE_DEV_ && $this->controller_type == 'admin') {
-            set_error_handler([__CLASS__, 'myErrorHandler']);
-        }
-
         if (!defined('_PS_BASE_URL_')) {
             define('_PS_BASE_URL_', Tools::getShopDomain(true));
         }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1271,8 +1271,29 @@ class FrontControllerCore extends Controller
         if (isset($this->php_self) && $this->php_self == 'order-confirmation') {
             $extraJsConf = Configuration::get(Configuration::CUSTOMCODE_ORDERCONF_JS);
         }
+        $debugMessages = '';
+        if (_PS_MODE_DEV_) {
+            $debugMessages .= "\n";
+            forEach(ErrorHandler::getInstance()->getErrorMessages(false) as $errorMessage) {
+                $printMessage = 'console.';
+                switch ($errorMessage['level']) {
+                    case 'warning':
+                    case 'notice':
+                        $printMessage .= 'warn';
+                        break;
+                    case 'error':
+                        $printMessage .= 'error';
+                        break;
+                    default:
+                        $printMessage .= 'log';
+                }
+                $strMessage = ErrorHandler::formatErrorMessage($errorMessage);
+                $printMessage .= '(' . json_encode($strMessage) . ');';
+                $debugMessages .= $printMessage . "\n";
+            }
+        }
 
-        $hookFooter .= '<script>'.$extraJs.$extraJsConf.'</script>';
+        $hookFooter .= '<script>'.$extraJs.$extraJsConf.$debugMessages.'</script>';
 
         $this->context->smarty->assign(
             [

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1273,23 +1273,34 @@ class FrontControllerCore extends Controller
         }
         $debugMessages = '';
         if (_PS_MODE_DEV_) {
-            $debugMessages .= "\n";
-            forEach(ErrorHandler::getInstance()->getErrorMessages(false) as $errorMessage) {
-                $printMessage = 'console.';
-                switch ($errorMessage['level']) {
-                    case 'warning':
-                    case 'notice':
-                        $printMessage .= 'warn';
-                        break;
-                    case 'error':
-                        $printMessage .= 'error';
-                        break;
-                    default:
-                        $printMessage .= 'log';
+            $messages = ErrorHandler::getInstance()->getErrorMessages(false);
+            if ($messages) {
+                $debugMessages = "\n";
+                $debugMessages .= 'if(window.console && window.console.group && window.console.log && window.console.warn && window.console.error) {' . "\n";
+                $debugMessages .= '  console.group("PHP error messages");' . "\n";
+                forEach (ErrorHandler::getInstance()->getErrorMessages(false) as $errorMessage) {
+                    $printMessage = '  console.';
+                    $color = "black";
+                    switch ($errorMessage['level']) {
+                        case 'warning':
+                        case 'notice':
+                            $printMessage .= 'warn';
+                            $color = "#B23B13";
+                            break;
+                        case 'error':
+                            $printMessage .= 'error';
+                            $color = "red";
+                            break;
+                        default:
+                            $printMessage .= 'log';
+                    }
+                    $file = ErrorHandler::normalizeFileName($errorMessage['errfile']);
+                    $strMessage = '%c' . $errorMessage['type'] . ': %c' . $errorMessage['errstr'] . ' %cin %c' . $file . ' %cat line %c' . $errorMessage['errline'];
+                    $printMessage .= '(' . json_encode($strMessage) . ', "color: '.$color.'", "color: blue; font-weight: bold", "color: grey", "color:green", "color: grey", "color:green");';
+                    $debugMessages .= $printMessage . "\n";
                 }
-                $strMessage = ErrorHandler::formatErrorMessage($errorMessage);
-                $printMessage .= '(' . json_encode($strMessage) . ');';
-                $debugMessages .= $printMessage . "\n";
+                $debugMessages .= "  console.groupEnd();\n";
+                $debugMessages .= "}\n";
             }
         }
 

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -83,12 +83,6 @@ if (_PS_DEBUG_PROFILING_) {
     include_once(_PS_TOOL_DIR_.'profiling/Tools.php');
 }
 
-/* Set uncaught exception handler */
-set_exception_handler(function ($e) {
-    $exception = new PrestaShopException($e->getMessage(), $e->getCode(), null, $e->getTrace(), $e->getFile(), $e->getLine());
-    $exception->displayMessage();
-});
-
 if (Tools::convertBytes(ini_get('upload_max_filesize')) < Tools::convertBytes('100M')) {
     ini_set('upload_max_filesize', '100M');
 }

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -66,6 +66,9 @@ if (!file_exists(_PS_ROOT_DIR_.'/config/settings.inc.php')) {
 require_once(_PS_ROOT_DIR_.'/config/settings.inc.php');
 require_once(_PS_CONFIG_DIR_.'autoload.php');
 
+/* Initialize error reporting logic */
+ErrorHandler::getInstance()->init();
+
 require_once $currentDir . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 /* Custom config made by users */

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -37,15 +37,8 @@ if (!defined('_PS_MODE_DEV_')) {
 if (!defined('_PS_DISPLAY_COMPATIBILITY_WARNING_')) {
     define('_PS_DISPLAY_COMPATIBILITY_WARNING_', false);
 }
-if (_PS_MODE_DEV_ === true) {
-    @ini_set('display_errors', 'on');
-    @error_reporting(E_ALL | E_STRICT);
-    define('_PS_DEBUG_SQL_', true);
-} else {
-    @ini_set('display_errors', 'off');
-    @error_reporting(E_ALL ^ E_DEPRECATED);
-    define('_PS_DEBUG_SQL_', false);
-}
+
+define('_PS_DEBUG_SQL_', _PS_MODE_DEV_);
 
 if (!defined('_PS_DEBUG_PROFILING_')) {
     define('_PS_DEBUG_PROFILING_', false);

--- a/tests/_support/override/classes/ErrorHandler.php
+++ b/tests/_support/override/classes/ErrorHandler.php
@@ -1,0 +1,6 @@
+<?php
+
+class ErrorHandler extends ErrorHandlerCore
+{
+}
+

--- a/tests/_support/unitloadclasses.php
+++ b/tests/_support/unitloadclasses.php
@@ -495,6 +495,8 @@ $kernel->loadFile(__DIR__.'/../../classes/webservice/WebserviceSpecificManagemen
 $kernel->loadFile(__DIR__.'/override/classes/webservice/WebserviceSpecificManagementSearch.php');
 $kernel->loadFile(__DIR__.'/../../classes/Zone.php');
 $kernel->loadFile(__DIR__.'/override/classes/Zone.php');
+$kernel->loadFile(__DIR__.'/../../classes/ErrorHandler.php');
+$kernel->loadFile(__DIR__.'/override/classes/ErrorHandler.php');
 
 $kernel->loadFile(__DIR__.'/../../controllers/admin/AdminAccessController.php');
 $kernel->loadFile(__DIR__.'/override/controllers/admin/AdminAccessController.php');


### PR DESCRIPTION
@Traumflug please review and give me your opinions on this change

Current implementation of debug mode depends on [display_errors](http://php.net/manual/en/errorfunc.configuration.php#ini.display-errors) settings. That means that all errors (including warnings and notices) are printed to the screen as part of the output. 

This behavior can break HTML markup significantly. But what's even worse, these error messages are even printed into ajax call response. If ajax call is supposed to return JSON data then such *enhanced* response can't be parsed.

Code in this branch is a proposed solution for this problem. It disable display_errors, and collect all errors and warnings instead (note that this was already implemented in back office). Collected error messages are then presented to user using [php-debugbar](https://github.com/maximebf/php-debugbar), both on backend and on frontend.

Using debugBar, we will be able to collect and display to user variety of interesting data in the future, such as sql queries, cache performance, etc... 

If you want to test the code, you will need to install new composer packages.

<img width="500" alt="debugbar" src="https://user-images.githubusercontent.com/34651851/51167727-8fa3ea00-18a7-11e9-95e5-9126449bc0cc.png">


