### PR TITLE
Do not escape htaccess

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3189,7 +3189,7 @@ class ToolsCore
         $specific_before = $specific_after = '';
         if (file_exists($path)) {
             if (static::isSubmit('htaccess')) {
-                $content = static::getValue('htaccess');
+                $content = $_POST['htaccess'];
             } else {
                 $content = file_get_contents($path);
             }

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -260,7 +260,7 @@ class AdminMetaControllerCore extends AdminController
                     'enableLiveAutocompletion'  => true,
                     'maxLines'                  => 400,
                     'visibility'                => Shop::CONTEXT_ALL,
-                    'value'                     => Tools::isSubmit('htaccess') ? Tools::getValue('htaccess') : @file_get_contents(_PS_ROOT_DIR_.'/.htaccess'),
+                    'value'                     => Tools::isSubmit('htaccess') ? $_POST['htaccess'] : @file_get_contents(_PS_ROOT_DIR_.'/.htaccess'),
                     'auto_value'                => false,
                 ],
             ],
@@ -877,7 +877,7 @@ class AdminMetaControllerCore extends AdminController
      */
     public function saveHtaccessFile()
     {
-        @file_put_contents(_PS_ROOT_DIR_.'/.htaccess', Tools::getValue('htaccess'));
+        @file_put_contents(_PS_ROOT_DIR_.'/.htaccess', $_POST['htaccess']);
     }
 
     /**


### PR DESCRIPTION
$_POST['htaccess'] should be taken as-is, and not escaped with Tools::getValue(), which strips slashes.

If .htaccess contains instructions which need backslash, saving meta's will remove those backslashes and will break the htaccess, breaking the website.