### PR TITLE
Update PaymentModule.php

### DIFF
--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -736,7 +736,7 @@ abstract class PaymentModuleCore extends Module
                         ];
 
                         // If the reduction is not applicable to this order, then continue with the next one
-                        if (!$values['tax_excl']) {
+                        if (!$values['tax_excl'] && !$values['tax_incl']) {
                             continue;
                         }
 


### PR DESCRIPTION
When you create a coupon with a reduction of a certain amount with tax included, it is not added on the order_cart_rule database and therefore not visible on the back office and on invoices, that was a bug because "// If the reduction is not applicable to this order, then continue with the next one" doesn't mean much thing.. the reduction is applicable, the rest of the code shows it.
Tested and it work much better now.. and when a customer use a coupon, it is decreased of the times he can use it, so if it is a one shot coupon for one customer, it will block this customer to use it again and again.