### PR TITLE
Fix bad css path when shop has base URI (IE <= 9)

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -831,7 +831,7 @@ class MediaCore
         foreach ($compiledCss as $css => $media) {
             $fileInfo = parse_url($css);
             $fileBasename = basename($fileInfo['path']);
-            $cssContent = file_get_contents(_PS_ROOT_DIR_.$fileInfo['path']);
+            $cssContent = file_get_contents(_PS_ROOT_DIR_.Tools::str_replace_once(__PS_BASE_URI__, '/', $fileInfo['path']));
             $count = $splitter->countSelectors($cssContent) - $cssRuleLimit;
             if (($count / $cssRuleLimit) > 0) {
                 $part = 2;


### PR DESCRIPTION
Based on https://github.com/PrestaShop/PrestaShop/pull/12554