### PR TITLE
Fixing favicon readfile

### DIFF
--- a/controllers/front/FaviconController.php
+++ b/controllers/front/FaviconController.php
@@ -66,7 +66,7 @@ class FaviconControllerCore extends FrontController
         }
 
         header('Content-Type: image/x-icon');
-        readfile(_PS_IMG_DIR_."favicon_{$this->context->shop->id}.ico");
+        readfile(_PS_IMG_DIR_."favicon-{$this->context->shop->id}.ico");
         exit;
     }
 }


### PR DESCRIPTION
As far as I can see the favicons are saved in the format: favicon-{id_shop}.ico.

Thats why I have logs like: PHP Warning: readfile(/path/img/favicon_1.ico): failed to open stream: No such file or directory in ...