### PR TITLE
Change sorting of customer threads to last message

### DIFF
--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -284,7 +284,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
         }
 
         $this->_group = 'GROUP BY cm.id_customer_thread';
-        $this->_orderBy = 'id_customer_thread';
+        $this->_orderBy = 'date_upd';
         $this->_orderWay = 'DESC';
 
         $contacts = CustomerThread::getContacts();


### PR DESCRIPTION
The default sort by id_customer_thread is very confusing. Imagine you get an answer from an old customer, which already wrote some years before. This message will be appended and has a low id_customer_thread. So as a merchant you will not even realize, where this message is.

From a practical standpoint its clear: last message needs to be default sorting.