### PR TITLE
Fix list count when using group_by

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1154,7 +1154,7 @@ class AdminControllerCore extends Controller
                 $this->_listsql = 'SELECT
 								'.($this->_tmpTableFilter ? ' * FROM (SELECT ' : '').$this->_listsql.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere.
                     $sqlOrderBy.$sqlLimit;
-                $listCount = 'SELECT COUNT(*) AS `'._DB_PREFIX_.$this->table.'` '.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere;
+                $listCount = 'SELECT COUNT(*) FROM (SELECT a.'.$this->identifier.' '.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere.') AS `count`';
             }
 
             $this->_list = Db::getInstance()->executeS($this->_listsql, true, false);

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1154,7 +1154,12 @@ class AdminControllerCore extends Controller
                 $this->_listsql = 'SELECT
 								'.($this->_tmpTableFilter ? ' * FROM (SELECT ' : '').$this->_listsql.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere.
                     $sqlOrderBy.$sqlLimit;
-                $listCount = 'SELECT COUNT(*) FROM (SELECT a.'.$this->identifier.' '.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere.') AS `count`';
+                if ($this->_group) {
+                    $listCount = 'SELECT COUNT(*) AS `'._DB_PREFIX_.$this->table.'` FROM (SELECT 1 '.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere.') AS `inner`';
+                }
+                else {
+                    $listCount = 'SELECT COUNT(*) AS `'._DB_PREFIX_.$this->table.'` '.$sqlFrom.$sqlJoin.' WHERE 1 '.$sqlWhere;
+                }
             }
 
             $this->_list = Db::getInstance()->executeS($this->_listsql, true, false);


### PR DESCRIPTION
If you change a backoffice list with group_by, the total count does fail.

To reproduce use the simple:
`public function hookActionAdminProductsListingFieldsModifier($params) {
    $params['group_by'] = 'GROUP BY a.id_product';
}`

My fix will lead to a correct _listTotal value. The if condition is for performance reason.