### PR TITLE
Succed  a search even with spelling errors

### DIFF
--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -87,10 +87,11 @@ class SearchControllerCore extends FrontController
             if(empty($searchResults))
                 $searchResults = Search::find((int) (Tools::getValue('id_lang')), self::findFirstClosestWord($query), 1, 10, 'position', 'desc', true);
             
-            foreach ($searchResults as &$product) {
-                $product['product_link'] = $this->context->link->getProductLink($product['id_product'], $product['prewrite'], $product['crewrite']);
-            }
-            Hook::exec('actionSearch', ['expr' => $query, 'total' => count($searchResults)]);
+            if (is_array($searchResults)) {
+                foreach ($searchResults as &$product) {
+                    $product['product_link'] = $this->context->link->getProductLink($product['id_product'], $product['prewrite'], $product['crewrite']);
+                }
+                Hook::exec('actionSearch', ['expr' => $query, 'total' => count($searchResults)]);
             
             $this->ajaxDie(json_encode($searchResults));
         }

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -277,7 +277,7 @@ class SearchControllerCore extends FrontController
 
                 return $cache[$a['word']] < $cache[$b['word']] ? $a : $b;
 
-            }, array ( "word" => 'initial', 'distance' => 10, 'weight' => 0 ))['word'];
+            }, array ( "word" => 'initial' ))['word'];
 
             unset($cache);
             if(next($queries))

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -231,9 +231,11 @@ class SearchControllerCore extends FrontController
         }
     }
     
-    
     /**
+     * findFirstCloseWord
+     *
      * @param $searchString
+     *
      * @return mixed
      */
     static function findFirstCloseWord($searchString)
@@ -247,13 +249,16 @@ class SearchControllerCore extends FrontController
             return $a['leven'] > $b['leven'] ? 1 : -1;
         });
 
-
         return array_shift($words)['word'];
     }
 
     /**
+     * utf8_to_extended_ascii
+     *
      * @param $str
+     *
      * @param $map
+     *
      * @return string
      */
     static function utf8_to_extended_ascii($str, &$map)
@@ -270,10 +275,13 @@ class SearchControllerCore extends FrontController
         return strtr($str, $map);
     }
 
-
     /**
+     * levenshtein_utf8
+     *
      * @param $s1
+     *
      * @param $s2
+     * 
      * @return int
      */
     static function levenshtein_utf8($s1, $s2)
@@ -286,14 +294,14 @@ class SearchControllerCore extends FrontController
     }
 
     /**
+     * getAllWords
+     *
      * @return array|false|PDOStatement|null
      */
     static function getAllWords()
     {
         $sql = 'SELECT `word` FROM `'._DB_PREFIX_.'search_word` WHERE `id_lang` = '.(int)Context::getContext()->language->id.';';
 
-        $result = Db::getInstance()->executeS($sql);
-
-        return $result;
+        return Db::getInstance()->executeS($sql);
     }
 }

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -245,11 +245,9 @@ class SearchControllerCore extends FrontController
         foreach ( $words as &$item )
             $item['leven'] = self::levenshtein_utf8($item['word'], $searchString);
 
-        uasort($words, function ($a, $b) {
-            return $a['leven'] > $b['leven'] ? 1 : -1;
-        });
-
-        return array_shift($words)['word'];
+        return array_reduce($words, function($a, $b){
+            return $a['leven'] < $b['leven'] ? $a : $b;
+        }, array_shift($words))['word'];
     }
 
     /**
@@ -264,6 +262,7 @@ class SearchControllerCore extends FrontController
     static function utf8_to_extended_ascii($str, &$map)
     {
         $matches = array();
+        
         if (!preg_match_all('/[\xC0-\xF7][\x80-\xBF]+/', $str, $matches))
             return $str;
 

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -277,11 +277,12 @@ class SearchControllerCore extends FrontController
 
                 return $cache[$a['word']] < $cache[$b['word']] ? $a : $b;
 
-            }, array ( "word" => 'initial' ))['word'];
+            }, array ("word" => 'initial'))['word'];
 
-            unset($cache);
-            if(next($queries))
+            if(next($queries)) {
+                unset($cache);
                 $closestWords .= ' ';
+            }
         }
 
         return $closestWords;

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -92,7 +92,7 @@ class SearchControllerCore extends FrontController
                     $product['product_link'] = $this->context->link->getProductLink($product['id_product'], $product['prewrite'], $product['crewrite']);
                 }
                 Hook::exec('actionSearch', ['expr' => $query, 'total' => count($searchResults)]);
-            
+            }
             $this->ajaxDie(json_encode($searchResults));
         }
 

--- a/controllers/front/SearchController.php
+++ b/controllers/front/SearchController.php
@@ -267,7 +267,6 @@ class SearchControllerCore extends FrontController
         if (!preg_match_all('/[\xC0-\xF7][\x80-\xBF]+/', $str, $matches))
             return $str;
 
-
         foreach ($matches[0] as $mbc)
             if (!isset($map[$mbc]))
                 $map[$mbc] = chr(128 + count($map));


### PR DESCRIPTION
Hi,
Here, just an implementation of the Levenshtein algorithm.
https://www.php.net/manual/en/function.levenshtein.php

The goal is to find some products with the search functionality. Even if you get some miss spelling in the search input.
That works perfectly with the vanilla ThirtyBees shop with default product.

For example, you search  "chonney" instead of "honey", search controller will be able to find the close word, here honey, and will display honey product in the result.
![Tooltip_020](https://user-images.githubusercontent.com/6756795/59548874-50c1af80-8f7f-11e9-8c4c-81e459e4f2d9.png)

Some precisions about the changes:
-------------------------------------------------
a. In case there are many close words, we take the first of the list.
b. The algorithm is really fast, only 0.005 - 0.010 second to check 2000 words !
b. The algorithm could find some words, really far for the original (schlzcolad -> chocolat).
c. Later in a another commit, we could choose the better word following some requirements.

To explain a little what I added:
-----------------------------------------
1. Add a condition to check if result is empty or not. In case it's empty, try another search with the first word close to the query string (line 87-89).
2. Add method to find the closest word from the query string  (line 234 - 258)

Regards,
Lathanao