### PR TITLE
Added custom date formats in CSV import

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -117,6 +117,17 @@
 					<p class="help-block">{l s='Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.'}</p>
 				</div>
 			</div>
+			<div id="dateFormatContainer" class="form-group" {if !$date_formats}style="display:none"{/if}>
+				<label class="control-label col-lg-3" for="date_format">{l s='Date format'}</label>
+				<div id="selectDivDateFormat" class="col-lg-9">
+					<select class="fixed-width-lg" name="date_format" id="date_format">
+						{foreach $date_formats as $value => $format}
+							<option value="{$value}">{$format.label}</option>
+						{/foreach}
+					</select>
+					<p class="help-block">{l s='Applied on all imported dates.'}</p>
+				</div>
+			</div>
 			<div class="form-group">
 				<div class="col-lg-12">
 					{section name=nb_i start=0 loop=$nb_table step=1}

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -117,17 +117,6 @@
 					<p class="help-block">{l s='Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.'}</p>
 				</div>
 			</div>
-			<div id="dateFormatContainer" class="form-group" style="display:none">
-				<label class="control-label col-lg-3" for="date_format">{l s='Custom date format'}</label>
-				<div id="selectDivDateFormat" class="col-lg-2">
-					<select name="date_format" id="date_format">
-						{foreach $date_formats as $value => $format}
-							<option value="{$value}">{$format.label}</option>
-						{/foreach}
-					</select>
-					<p class="help-block">{l s='Applied on discount from and to dates.'}</p>
-				</div>
-			</div>
 			<div class="form-group">
 				<div class="col-lg-12">
 					{section name=nb_i start=0 loop=$nb_table step=1}

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -117,6 +117,17 @@
 					<p class="help-block">{l s='Indicate how many of the first rows of your file should be skipped when importing the data. For instance set it to 1 if the first row of your file contains headers.'}</p>
 				</div>
 			</div>
+			<div id="dateFormatContainer" class="form-group" style="display:none">
+				<label class="control-label col-lg-3" for="date_format">{l s='Custom date format'}</label>
+				<div id="selectDivDateFormat" class="col-lg-2">
+					<select name="date_format" id="date_format">
+						{foreach $date_formats as $value => $format}
+							<option value="{$value}">{$format.label}</option>
+						{/foreach}
+					</select>
+					<p class="help-block">{l s='Applied on discount from and to dates.'}</p>
+				</div>
+			</div>
 			<div class="form-group">
 				<div class="col-lg-12">
 					{section name=nb_i start=0 loop=$nb_table step=1}

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -843,8 +843,8 @@ class ToolsCore
             $currencyIso = $tbCurrency['iso_code'];
             $currencyDecimals
                 = (int) $tbCurrency['decimals'] ?
-                  Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
-                  0;
+                Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
+                0;
             $currencyArray = $tbCurrency;
             $tbCurrency = new Currency();
             $tbCurrency->hydrate($currencyArray);
@@ -852,8 +852,8 @@ class ToolsCore
             $currencyIso = $tbCurrency->iso_code;
             $currencyDecimals
                 = (int) $tbCurrency->decimals ?
-                  Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
-                  0;
+                Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
+                0;
         } else {
             return '';
         }
@@ -870,8 +870,8 @@ class ToolsCore
             $cChar = $tbCurrency->sign;
             $cFormat = $tbCurrency->format;
             $cDecimals = (int) $tbCurrency->decimals ?
-                         Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
-                         0;
+                Configuration::get('PS_PRICE_DISPLAY_PRECISION') :
+                0;
             $cBlank = $tbCurrency->blank;
             $blank = ($cBlank ? ' ' : '');
             $ret = 0;
@@ -2632,8 +2632,8 @@ class ToolsCore
                 $row['id_product'],
                 true,
                 (isset($row['id_product_attribute'])
-                && ! empty($row['id_product_attribute'])) ?
-                  (int) $row['id_product_attribute'] : null
+                    && ! empty($row['id_product_attribute'])) ?
+                    (int) $row['id_product_attribute'] : null
             );
         }
 
@@ -5330,6 +5330,31 @@ FileETag none
         }
 
         return $timezone;
+    }
+
+    /**
+     * Converts date from given format to result format
+     *
+     * @param $format
+     * @param $date
+     * @param string $resultFormat
+     * @return string
+     *
+     * @since   1.0.8
+     */
+    public static function getDateFromDateFormat($format, $date, $resultFormat = 'Y-m-d H:i:s')
+    {
+        $d = DateTime::createFromFormat($format, $date);
+        if ($d && $d->format($format) == $date) {
+            if ($resultFormat === 'Y-m-d H:i:s') {
+                $d->setTime(0, 0, 0);
+                return $d->format($resultFormat);
+            } else {
+                return $d->format($resultFormat);
+            }
+        } else {
+            return null;
+        }
     }
 }
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -246,8 +246,6 @@ class AdminImportControllerCore extends AdminController
                     'reduction_percent'         => ['label' => $this->l('Discount percent')],
                     'reduction_from'            => ['label' => $this->l('Discount from (yyyy-mm-dd)')],
                     'reduction_to'              => ['label' => $this->l('Discount to (yyyy-mm-dd)')],
-                    'reduction_from_custom'     => ['label' => $this->l('Discount from (custom)')],
-                    'reduction_to_custom'       => ['label' => $this->l('Discount to (custom)')],
                     'reference'                 => ['label' => $this->l('Reference #')],
                     'supplier_reference'        => ['label' => $this->l('Supplier reference #')],
                     'supplier'                  => ['label' => $this->l('Supplier')],
@@ -832,16 +830,6 @@ class AdminImportControllerCore extends AdminController
         $this->context->cookie->multipleValueSeparatorSelected = urlencode($this->multiple_value_separator);
         $this->context->cookie->csv_selected = urlencode(Tools::getValue('csv'));
 
-        $date_formats = [
-            'Y-m-d' => ['label' => 'Y-m-d'],
-            'Y-d-m' => ['label' => 'Y-d-m'],
-            'd-m-Y' => ['label' => 'd-m-Y'],
-            'd.m.Y' => ['label' => 'd.m.Y'],
-        ];
-        if (!empty($this->context->language) && !empty($this->context->language->date_format_lite)) {
-            $date_formats = array_merge([$this->context->language->date_format_lite => ['label' => $this->context->language->date_format_lite . ' - ' . $this->l('from language')]], $date_formats);
-        }
-
         $this->tpl_view_vars = [
             'import_matchs'    => Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS((new DbQuery())->select('*')->from('import_match'), true, false),
             'fields_value'     => [
@@ -863,7 +851,6 @@ class AdminImportControllerCore extends AdminController
             'no_pre_select'    => ['price_tin', 'feature'],
             'available_fields' => $this->available_fields,
             'data'             => $data,
-            'date_formats'     => $date_formats,
         ];
 
         return parent::renderView();
@@ -2934,23 +2921,8 @@ class AdminImportControllerCore extends AdminController
                         $info['reduction_percent'] / 100
                     );
                     $specificPrice->reduction_type = (isset($info['reduction_price']) && $info['reduction_price']) ? 'amount' : 'percentage';
-
-                    if (isset($info['reduction_from_custom']) && Tools::getValue('date_format') && Validate::isPhpDateFormat(Tools::getValue('date_format'))) {
-                        $specificPrice->from = \DateTime::createFromFormat(Tools::getValue('date_format'), $info['reduction_from_custom']);
-                        if(is_a($specificPrice->from, 'DateTime')){
-                            $specificPrice->from = $specificPrice->from->format('Y-m-d');
-                        }
-                    } else {
-                        $specificPrice->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
-                    }
-                    if (isset($info['reduction_to_custom']) && Tools::getValue('date_format') && Validate::isPhpDateFormat(Tools::getValue('date_format'))) {
-                        $specificPrice->to = \DateTime::createFromFormat(Tools::getValue('date_format'), $info['reduction_to_custom']);
-                        if(is_a($specificPrice->to, 'DateTime')){
-                            $specificPrice->to = $specificPrice->to->format('Y-m-d');
-                        }
-                    } else {
-                        $specificPrice->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to'])) ? $info['reduction_to'] : '0000-00-00 00:00:00';
-                    }
+                    $specificPrice->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
+                    $specificPrice->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to'])) ? $info['reduction_to'] : '0000-00-00 00:00:00';
                     if (!$validateOnly && !$specificPrice->save()) {
                         $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Discount is invalid'));
                     }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -246,6 +246,8 @@ class AdminImportControllerCore extends AdminController
                     'reduction_percent'         => ['label' => $this->l('Discount percent')],
                     'reduction_from'            => ['label' => $this->l('Discount from (yyyy-mm-dd)')],
                     'reduction_to'              => ['label' => $this->l('Discount to (yyyy-mm-dd)')],
+                    'reduction_from_custom'     => ['label' => $this->l('Discount from (custom)')],
+                    'reduction_to_custom'       => ['label' => $this->l('Discount to (custom)')],
                     'reference'                 => ['label' => $this->l('Reference #')],
                     'supplier_reference'        => ['label' => $this->l('Supplier reference #')],
                     'supplier'                  => ['label' => $this->l('Supplier')],
@@ -830,6 +832,16 @@ class AdminImportControllerCore extends AdminController
         $this->context->cookie->multipleValueSeparatorSelected = urlencode($this->multiple_value_separator);
         $this->context->cookie->csv_selected = urlencode(Tools::getValue('csv'));
 
+        $date_formats = [
+            'Y-m-d' => ['label' => 'Y-m-d'],
+            'Y-d-m' => ['label' => 'Y-d-m'],
+            'd-m-Y' => ['label' => 'd-m-Y'],
+            'd.m.Y' => ['label' => 'd.m.Y'],
+        ];
+        if (!empty($this->context->language) && !empty($this->context->language->date_format_lite)) {
+            $date_formats = array_merge([$this->context->language->date_format_lite => ['label' => $this->context->language->date_format_lite . ' - ' . $this->l('from language')]], $date_formats);
+        }
+
         $this->tpl_view_vars = [
             'import_matchs'    => Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS((new DbQuery())->select('*')->from('import_match'), true, false),
             'fields_value'     => [
@@ -851,6 +863,7 @@ class AdminImportControllerCore extends AdminController
             'no_pre_select'    => ['price_tin', 'feature'],
             'available_fields' => $this->available_fields,
             'data'             => $data,
+            'date_formats'     => $date_formats,
         ];
 
         return parent::renderView();
@@ -2921,8 +2934,23 @@ class AdminImportControllerCore extends AdminController
                         $info['reduction_percent'] / 100
                     );
                     $specificPrice->reduction_type = (isset($info['reduction_price']) && $info['reduction_price']) ? 'amount' : 'percentage';
-                    $specificPrice->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
-                    $specificPrice->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to'])) ? $info['reduction_to'] : '0000-00-00 00:00:00';
+
+                    if (isset($info['reduction_from_custom']) && Tools::getValue('date_format') && Validate::isPhpDateFormat(Tools::getValue('date_format'))) {
+                        $specificPrice->from = \DateTime::createFromFormat(Tools::getValue('date_format'), $info['reduction_from_custom']);
+                        if(is_a($specificPrice->from, 'DateTime')){
+                            $specificPrice->from = $specificPrice->from->format('Y-m-d');
+                        }
+                    } else {
+                        $specificPrice->from = (isset($info['reduction_from']) && Validate::isDate($info['reduction_from'])) ? $info['reduction_from'] : '0000-00-00 00:00:00';
+                    }
+                    if (isset($info['reduction_to_custom']) && Tools::getValue('date_format') && Validate::isPhpDateFormat(Tools::getValue('date_format'))) {
+                        $specificPrice->to = \DateTime::createFromFormat(Tools::getValue('date_format'), $info['reduction_to_custom']);
+                        if(is_a($specificPrice->to, 'DateTime')){
+                            $specificPrice->to = $specificPrice->to->format('Y-m-d');
+                        }
+                    } else {
+                        $specificPrice->to = (isset($info['reduction_to']) && Validate::isDate($info['reduction_to'])) ? $info['reduction_to'] : '0000-00-00 00:00:00';
+                    }
                     if (!$validateOnly && !$specificPrice->save()) {
                         $this->addProductWarning(Tools::safeOutput($info['name']), $product->id, $this->l('Discount is invalid'));
                     }

--- a/js/admin/import.js
+++ b/js/admin/import.js
@@ -330,6 +330,18 @@ function updateProgressionError(message, forWarnings) {
   }
 }
 
+function toggleDateFormatSelect() {
+  let elem, showInput = false;
+  for (let i = 0; elem = window.getE('type_value[' + i + ']'); i += 1) {
+    if (['reduction_to_custom', 'reduction_from_custom'].indexOf(elem.value) !== -1) {
+      showInput = true;
+    }
+  }
+  if (showInput)
+    $('#dateFormatContainer').show();
+  else
+    $('#dateFormatContainer').hide();
+}
 
 $(document).ready(function () {
   $('#saveImportMatchs').unbind('click').click(function () {
@@ -375,6 +387,7 @@ $(document).ready(function () {
         for (var i = 0; i < matchs.length; i += 1) {
           $('#type_value\\[' + i + '\\]').val(matchs[i]).attr('selected', true);
         }
+        toggleDateFormatSelect();
       },
       error: function (XMLHttpRequest) {
         window.jAlert('TECHNICAL ERROR Details: ' + window.html_escape(XMLHttpRequest.responseText));
@@ -426,4 +439,10 @@ $(document).ready(function () {
     $('#import_details_warning, #import_details_info').hide();
     window.importNow(0, 5, -1, false, {}, 0);
   });
+
+  for (var i = 0; elem = window.getE('type_value[' + i + ']'); i += 1) {
+    $(elem).unbind('change').change(function (event) {
+      toggleDateFormatSelect();
+    });
+  }
 });

--- a/js/admin/import.js
+++ b/js/admin/import.js
@@ -330,18 +330,6 @@ function updateProgressionError(message, forWarnings) {
   }
 }
 
-function toggleDateFormatSelect() {
-  let elem, showInput = false;
-  for (let i = 0; elem = window.getE('type_value[' + i + ']'); i += 1) {
-    if (['reduction_to_custom', 'reduction_from_custom'].indexOf(elem.value) !== -1) {
-      showInput = true;
-    }
-  }
-  if (showInput)
-    $('#dateFormatContainer').show();
-  else
-    $('#dateFormatContainer').hide();
-}
 
 $(document).ready(function () {
   $('#saveImportMatchs').unbind('click').click(function () {
@@ -387,7 +375,6 @@ $(document).ready(function () {
         for (var i = 0; i < matchs.length; i += 1) {
           $('#type_value\\[' + i + '\\]').val(matchs[i]).attr('selected', true);
         }
-        toggleDateFormatSelect();
       },
       error: function (XMLHttpRequest) {
         window.jAlert('TECHNICAL ERROR Details: ' + window.html_escape(XMLHttpRequest.responseText));
@@ -439,10 +426,4 @@ $(document).ready(function () {
     $('#import_details_warning, #import_details_info').hide();
     window.importNow(0, 5, -1, false, {}, 0);
   });
-
-  for (var i = 0; elem = window.getE('type_value[' + i + ']'); i += 1) {
-    $(elem).unbind('change').change(function (event) {
-      toggleDateFormatSelect();
-    });
-  }
 });


### PR DESCRIPTION
Added custom date formats in CSV import based on language settings and predefined values for discount range from-to. This opens a new select dropdown in "Match your data" step of CSV import if one of the fields selected for columns is discount from or to date.

Custom date formats are applied exclusively to the fields of the discount.