### PR TITLE
updated the hideFees function to not disable the zone checkboxes

### DIFF
--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -427,7 +427,9 @@ function bind_inputs() {
 }
 
 function hideFees() {
-  $('#zone_ranges .range_inf td input,#zone_ranges .range_sup td input,#zone_ranges .fees_all td input,#zone_ranges .fees td input').attr('disabled', 'disabled');
+  $('#zone_ranges .range_inf td input,#zone_ranges .range_sup td input,#zone_ranges .fees_all td input,#zone_ranges .fees td input')
+   .not('#zone_ranges .fees_all td input[type="checkbox"]').not('#zone_ranges .fees td input.input_zone')
+   .attr('disabled', 'disabled');
 }
 
 function showFees() {


### PR DESCRIPTION
Fix for issue #984 , jQuery selector for zone definition field chnaged to exclude the checkboxes fields. This will prevent the checkboxes from being disabed, so they will be submitted to the server and allowing the zone information to be created for the carrier. This is how it worked correctly before but was broken in an earlier release.