### PR TITLE
Fix for multistore-asm pppreferences bug

### DIFF
--- a/controllers/admin/AdminPPreferencesController.php
+++ b/controllers/admin/AdminPPreferencesController.php
@@ -328,7 +328,7 @@ class AdminPPreferencesControllerCore extends AdminController
         }
 
         // if advanced stock management is disabled, updates concerned tables
-        if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') == 1 && (int) Tools::getValue('PS_ADVANCED_STOCK_MANAGEMENT') == 0) {
+        if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') == 1 && (int)Tools::getValue('PS_ADVANCED_STOCK_MANAGEMENT') == 0 && Shop::getContext()==Shop::CONTEXT_ALL) {
             $idShopList = Shop::getContextListShopID();
             $sqlShop = 'UPDATE `'._DB_PREFIX_.'product_shop` SET `advanced_stock_management` = 0 WHERE
 			`advanced_stock_management` = 1 AND (`id_shop` = '.implode(' OR `id_shop` = ', $idShopList).')';


### PR DESCRIPTION
This is fixing https://github.com/thirtybees/thirtybees/issues/877.

The reason is, that Tools::getValue('PS_ADVANCED_STOCK_MANAGEMENT') is always 0, when you have selected a specific shop. 

As the field is set 'PS_ADVANCED_STOCK_MANAGEMENT' field ist set 'visibility' => Shop::CONTEXT_ALL. It means, that we must check if the merchant is on CONTEXT_ALL.