### PR TITLE
Add Availabilty filter search in back office

### DIFF
--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -181,6 +181,17 @@ class AdminSearchConfControllerCore extends AdminController
                             $this->l('It checks if the searched term is the exact end of the indexed word.'),
                         ],
                     ],
+		    'PS_SEARCH_INSTOCK'        => [
+                        'title'      => $this->l('Search in Stock'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                        'desc'       => $this->l('By default, all products are shown, filter the products that are available for order only in stock or pre-order .').'<br/>'.
+                            $this->l('With this option enabled, it will only gives results of available products for order.'),
+                        'hint'       => [
+                            $this->l('Enable more precise search with the in_stock/availability option.'),
+                        ],
+                    ],
                     'PS_SEARCH_MINWORDLEN' => [
                         'title'      => $this->l('Minimum word length (in characters)'),
                         'hint'       => $this->l('Only words this size or larger will be indexed.'),


### PR DESCRIPTION
adding a filter that is used on search.php class for giving more accurate results to customer in showing only available products for order.