### PR TITLE
ImageType::getFormatedName - compatibility

### DIFF
--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -221,6 +221,12 @@ class ImageTypeCore extends ObjectModel
             return $nameWithoutTheme.'_default';
         }
 
+        // if $name contains _default suffix, ie. home_default then try to resolve the name without this suffix
+        $pos = strpos($name, '_default');
+        if ($pos === strlen($name) - 8) {
+            return static::getFormatedName(substr($name, 0, $pos));
+        }
+
         // Give up searching.
         return $name;
     }


### PR DESCRIPTION
In 1.1.0 handling of image types was changed to better address
multistore / multitheme needs. Unfortunately, this introuces few
compatiblity issues.

One of them is the fact that many modules and/or themes are using
hardcoded image types like 'home_default' or 'large_default'. These
are now not resolved correctly, because the type is named 'home' and
'large'.

This is the fault of module using bad image type. But, unfortunately,
it is also very common usage.

This fix tries to resolve this situatio by trying to resolve image type
without _default suffix.