### PR TITLE
CSV Import: update default category

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
@@ -273,6 +273,23 @@
 					</div>
 				</div>
 				<div class="form-group">
+					<label for="forceCat" class="control-label col-lg-4">
+						<span data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='If you enable this option,  first category provided in file for each product will be used for default category.'}">
+							{l s='Force default category'}
+						</span>
+					</label>
+					<div class="col-lg-8">
+						<label class="switch-light prestashop-switch fixed-width-lg">
+							<input id="forceCat" name="forceCat" type="checkbox" />
+							<span>
+								<span>{l s='Yes'}</span>
+								<span>{l s='No'}</span>
+							</span>
+							<a class="slide-button btn"></a>
+						</label>
+					</div>
+				</div>
+				<div class="form-group">
 					<label for="sendemail" class="control-label col-lg-4">
 						<span data-toggle="tooltip" class="label-tooltip" data-original-title="{l s='Sends an email to let you know your import is complete. It can be useful when handling large files, as the import may take some time.'}">
 						{l s='Send notification email'}</label>

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -108,6 +108,9 @@
 			{if $fields_value.match_ref}
 				<input type="hidden" name="match_ref" value="1" />
 			{/if}
+			{if $fields_value.forceCat}
+				<input type="hidden" name="forceCat" value="1" />
+			{/if}
 			<input type="hidden" name="separator" value="{$fields_value.separator}" />
 			<input type="hidden" name="multiple_value_separator" value="{$fields_value.multiple_value_separator}" />
 			<div class="form-group">

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -857,6 +857,7 @@ class AdminImportControllerCore extends AdminController
                 'truncate'                 => Tools::getValue('truncate'),
                 'forceIDs'                 => Tools::getValue('forceIDs'),
                 'regenerate'               => Tools::getValue('regenerate'),
+		'forceCat' 	           => Tools::getValue('forceCat'),
                 'sendemail'                => Tools::getValue('sendemail'),
                 'match_ref'                => Tools::getValue('match_ref'),
                 'separator'                => $this->separator,
@@ -2709,8 +2710,8 @@ class AdminImportControllerCore extends AdminController
             $product->id_category = array_values(array_unique($product->id_category));
         }
 
-        // Will update default category if there is none set here. Home if no category at all.
-        if (!isset($product->id_category_default) || !$product->id_category_default) {
+        // Will update default category if forced or if there is none set here. Home if no category at all.
+        if ($forceCat || !isset($product->id_category_default) || !$product->id_category_default) {
             // this if will avoid ereasing default category if category column is not present in the CSV file (or ignored)
             if (isset($product->id_category[0])) {
                 $product->id_category_default = (int) $product->id_category[0];


### PR DESCRIPTION
adding more code for forcing default cat to update in product CSV import/update
reference to this issue :  #1058 

forum : https://forum.thirtybees.com/topic/3478-solved-issue-request-created-please-help-csv-product-import-problem-moving-category-issue-product-breadcrumb-not-updating-default-category-issue/