### PR TITLE
Fix error Property Employee->lastname is empty

### DIFF
--- a/classes/ShopMaintenance.php
+++ b/classes/ShopMaintenance.php
@@ -91,7 +91,7 @@ class ShopMaintenanceCore
             $employees = Employee::getEmployeesByProfile(_PS_ADMIN_PROFILE_);
             // Usually there's only one employee when we run this code.
             foreach ($employees as $employee) {
-                $employee = new Employee($employee);
+                $employee = new Employee($employee['id_employee']);
                 $employee->optin = true;
                 if ($employee->update()) {
                     Configuration::updateValue($name, 1);


### PR DESCRIPTION
Fixing error 500 on admin-dev/ajax.php file. 

Passing the Id employee in contructor.
And notifications can be displayed in backoffice head.
<img width="1411" alt="Capture d’écran 2020-01-02 à 18 44 37" src="https://user-images.githubusercontent.com/4788787/71682456-0e7f8480-2d90-11ea-872e-d63c0b9b9c9e.png">
