### PR TITLE
Show always the refund column in BO

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_product_line.tpl
@@ -113,26 +113,24 @@
 			{/if}
 		</td>
 	{/if}
-	{if ($order->hasBeenPaid())}
-		<td class="productQuantity text-center">
-			{if !empty($product['amount_refund'])}
-				{l s='%s (%s refund)' sprintf=[$product['product_quantity_refunded'], $product['amount_refund']]}
-			{/if}
-			<input type="hidden" value="{$product['quantity_refundable']}" class="partialRefundProductQuantity" />
-			<input type="hidden" value="{($product_price * ($product['product_quantity'] - $product['customizationQuantityTotal']))}" class="partialRefundProductAmount" />
-			{if count($product['refund_history'])}
-				<span class="tooltip">
-					<span class="tooltip_label tooltip_button">+</span>
-					<span class="tooltip_content">
-					<span class="title">{l s='Refund history'}</span>
-					{foreach $product['refund_history'] as $refund}
-						{l s='%1s - %2s' sprintf=[{dateFormat date=$refund.date_add}, {displayPrice price=$refund.amount_tax_incl}]}<br />
-					{/foreach}
-					</span>
+	<td class="productQuantity text-center">
+		{if !empty($product['amount_refund'])}
+			{l s='%s (%s refund)' sprintf=[$product['product_quantity_refunded'], $product['amount_refund']]}
+		{/if}
+		<input type="hidden" value="{$product['quantity_refundable']}" class="partialRefundProductQuantity" />
+		<input type="hidden" value="{($product_price * ($product['product_quantity'] - $product['customizationQuantityTotal']))}" class="partialRefundProductAmount" />
+		{if count($product['refund_history'])}
+			<span class="tooltip">
+				<span class="tooltip_label tooltip_button">+</span>
+				<span class="tooltip_content">
+				<span class="title">{l s='Refund history'}</span>
+				{foreach $product['refund_history'] as $refund}
+					{l s='%1s - %2s' sprintf=[{dateFormat date=$refund.date_add}, {displayPrice price=$refund.amount_tax_incl}]}<br />
+				{/foreach}
 				</span>
-			{/if}
-		</td>
-	{/if}
+			</span>
+		{/if}
+	</td>
 	{if $order->hasBeenDelivered() || $order->hasProductReturned()}
 		<td class="productQuantity text-center">
 			{$product['product_quantity_return']}

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -939,9 +939,9 @@
                 </th>
                 <th class="text-center"><span class="title_box ">{l s='Qty'}</span></th>
                 {if $display_warehouse}
-                  <th><span class="title_box ">{l s='Warehouse'}</span></th>{/if}
-                {if ($order->hasBeenPaid())}
-                  <th class="text-center"><span class="title_box ">{l s='Refunded'}</span></th>{/if}
+                  <th><span class="title_box ">{l s='Warehouse'}</span></th>
+                {/if}
+                <th class="text-center"><span class="title_box ">{l s='Refunded'}</span></th>
                 {if ($order->hasBeenDelivered() || $order->hasProductReturned())}
                   <th class="text-center"><span class="title_box ">{l s='Returned'}</span></th>
                 {/if}

--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -351,7 +351,7 @@ class OrderSlipCore extends ObjectModel
                 continue;
             }
 
-            if (!Tools::isSubmit('cancelProduct') && $order->hasBeenPaid()) {
+            if (!Tools::isSubmit('cancelProduct')) {
                 $orderDetail->product_quantity_refunded += $quantity;
             }
 


### PR DESCRIPTION
As we know from forum refunds/return management is an issue for many merchants:
- https://forum.thirtybees.com/topic/1134-1134/how-to-handle-returns
- https://forum.thirtybees.com/topic/3428-partial-refund-of-shipping-costs-not-possible

This is probably due to some bugs (which nobody exactly know if and where they exist). But in case of german merchants this also be due to a behaviour of tb. The shop system often considers, that a created order is paid. At least in german countries this is often untrue. It can happen, that you need to make a refund, even if the order is not yet paid.

This commit is a first step, to improve things a little bit. It shows the refund colums also if the order hasn't paid yet.