### PR TITLE
Fix issue-1134

### DIFF
--- a/classes/CustomerMessage.php
+++ b/classes/CustomerMessage.php
@@ -98,7 +98,7 @@ class CustomerMessageCore extends ObjectModel
 
     /**
      * @param int  $idOrder
-     * @param bool $private
+     * @param bool $hide_private
      *
      * @return array|false|mysqli_result|null|PDOStatement|resource
      *
@@ -107,7 +107,7 @@ class CustomerMessageCore extends ObjectModel
      * @since   1.0.0
      * @version 1.0.0 Initial version
      */
-    public static function getMessagesByOrderId($idOrder, $private = true)
+    public static function getMessagesByOrderId($idOrder, $hide_private = true)
     {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
             (new DbQuery())
@@ -122,7 +122,7 @@ class CustomerMessageCore extends ObjectModel
                 ->leftJoin('customer', 'c', 'ct.`id_customer` = c.`id_customer`')
                 ->leftOuterJoin('employee', 'e', 'e.`id_employee` = cm.`id_employee`')
                 ->where('ct.`id_order` = '.(int) $idOrder)
-                ->where($private ? 'cm.`private` = 0' : '')
+                ->where($hide_private ? 'cm.`private` = 0' : '')
                 ->groupBy('cm.`id_customer_message`')
                 ->orderBy('cm.`date_add` DESC')
         );

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -250,7 +250,7 @@ class OrderDetailControllerCore extends FrontController
                         'deliveryAddressFormatedValues' => $deliveryAddressFormatedValues,
                         'deliveryState'                 => (Validate::isLoadedObject($addressDelivery) && $addressDelivery->id_state) ? new State($addressDelivery->id_state) : false,
                         'is_guest'                      => false,
-                        'messages'                      => CustomerMessage::getMessagesByOrderId((int) $order->id, false),
+                        'messages'                      => CustomerMessage::getMessagesByOrderId((int) $order->id, true),
                         'CUSTOMIZE_FILE'                => Product::CUSTOMIZE_FILE,
                         'CUSTOMIZE_TEXTFIELD'           => Product::CUSTOMIZE_TEXTFIELD,
                         'isRecyclable'                  => Configuration::get('PS_RECYCLABLE_PACK'),


### PR DESCRIPTION
This fixes: https://github.com/thirtybees/thirtybees/issues/1134

The implications of $private is IMO confusing and probably that was the reason for the bug. When you set $private = true, it means you will get all messages that are not privat.