### PR TITLE
Improve customer messages (from order detail page)

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -849,17 +849,29 @@
               <div class="form-group">
                 <label class="control-label col-lg-3">{l s='Display to customer?'}</label>
                 <div class="col-lg-9">
-									<span class="switch prestashop-switch fixed-width-lg">
-										<input type="radio" name="visibility" id="visibility_on" value="0"/>
-										<label for="visibility_on">
-											{l s='Yes'}
-										</label>
-										<input type="radio" name="visibility" id="visibility_off" value="1" checked="checked"/>
-										<label for="visibility_off">
-											{l s='No'}
-										</label>
-										<a class="slide-button btn"></a>
-									</span>
+                    <span class="switch prestashop-switch fixed-width-lg">
+                        <input type="radio" name="visibility" id="visibility_on" value="0"/>
+                        <label for="visibility_on">
+                            {l s='Yes'}
+                        </label>
+                        <input type="radio" name="visibility" id="visibility_off" value="1" checked="checked"/>
+                        <label for="visibility_off">
+                            {l s='No'}
+                        </label>
+                        <a class="slide-button btn"></a>
+                    </span>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label for="status_msg" class="control-label col-lg-3">{l s='Status'}</label>
+                <div class="col-lg-9">
+                  <select id="status_msg" name="status_msg">
+                    <option value="open" {if isset($customer_thread_message[0]['status']) && $customer_thread_message[0]['status']=='open'}selected{/if}>{l s='Open'}</option>
+                    <option value="closed" {if isset($customer_thread_message[0]['status']) && $customer_thread_message[0]['status']=='closed'}selected{/if}>{l s='Closed'}</option>
+                    <option value="pending1" {if isset($customer_thread_message[0]['status']) && $customer_thread_message[0]['status']=='pending1'}selected{/if}>{l s='Pending 1'}</option>
+                    <option value="pending2" {if isset($customer_thread_message[0]['status']) && $customer_thread_message[0]['status']=='pending2'}selected{/if}>{l s='Pending 2'}</option>
+                  </select>
                 </div>
               </div>
 

--- a/classes/CustomerThread.php
+++ b/classes/CustomerThread.php
@@ -160,7 +160,6 @@ class CustomerThreadCore extends ObjectModel
                 ->select('cm.`id_customer_thread`')
                 ->from('customer_thread', 'cm')
                 ->where('cm.`email` = \''.pSQL($email).'\'')
-                ->where('cm.`id_shop` = '.(int) Context::getContext()->shop->id)
                 ->where('cm.`id_order` = '.(int) $idOrder)
         );
     }

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -751,15 +751,19 @@ class AdminOrdersControllerCore extends AdminController
                             $customerThread = new CustomerThread();
                             $customerThread->id_contact = 0;
                             $customerThread->id_customer = (int) $order->id_customer;
-                            $customerThread->id_shop = (int) $this->context->shop->id;
+                            $customerThread->id_shop = (int) $order->id_shop;
                             $customerThread->id_order = (int) $order->id;
                             $customerThread->id_lang = (int) $this->context->language->id;
                             $customerThread->email = $customer->email;
-                            $customerThread->status = 'open';
+                            $customerThread->status = Tools::getValue('status_msg');
                             $customerThread->token = Tools::passwdGen(12);
                             $customerThread->add();
                         } else {
-                            $customerThread = new CustomerThread((int) $idCustomerThread);
+                            $customerThread = new CustomerThread((int) $idCustomerThread);                            
+                            if ($customerThread->status!=Tools::getValue('status_msg')) {
+                                $customerThread->status = Tools::getValue('status_msg');
+                                $customerThread->update();
+                            }
                         }
 
                         $customerMessage = new CustomerMessage();


### PR DESCRIPTION
This PR is a first step, to improve the customer messaging system. 

- It removes issues in multistore mode (don't open multiple threads). 
- It adds a select on the order detail page in the backoffice. It's now possible to update the customer message thread status from there. That's very useful as you often respond/send a message from there, but wanna close the thread right afterwards.

![screen](https://user-images.githubusercontent.com/15154932/72457116-30ccc580-37c6-11ea-95c4-37fbfb083fe2.JPG)

