### PR TITLE
Extend Shipping Carriers options with additional cart total price range

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -107,6 +107,12 @@ class CarrierCore extends ObjectModel
     public $max_height;
     /** @var int maximum package deep managed by the transporter */
     public $max_depth;
+    /** @var int minimum cart total managed by the transporter */
+    public $min_total;
+    /** @var int maximum cart total managed by the transporter */
+    public $max_total;
+    /** @var int minimum package weight managed by the transporter */
+    public $min_weight;
     /** @var int maximum package weight managed by the transporter */
     public $max_weight;
     /** @var int grade of the shipping delay (0 for longest, 9 for shortest) */
@@ -143,6 +149,9 @@ class CarrierCore extends ObjectModel
             'max_width'            => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbType' => 'int(10)', 'dbDefault' => '0', 'dbNullable' => true],
             'max_height'           => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbType' => 'int(10)', 'dbDefault' => '0', 'dbNullable' => true],
             'max_depth'            => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbType' => 'int(10)', 'dbDefault' => '0', 'dbNullable' => true],
+            'min_total'           => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'dbDefault' => '0.000000', 'dbNullable' => true],
+            'max_total'           => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'dbDefault' => '0.000000', 'dbNullable' => true],
+            'min_weight'           => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'dbDefault' => '0.000000', 'dbNullable' => true],		
             'max_weight'           => ['type' => self::TYPE_FLOAT, 'validate' => 'isFloat', 'dbDefault' => '0.000000', 'dbNullable' => true],
             'grade'                => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'dbType' => 'int(10)', 'size' => 1, 'dbDefault' => '0', 'dbNullable' => true],
 
@@ -706,6 +715,21 @@ class CarrierCore extends ObjectModel
                     unset($carrierList[$key]);
                 }
 
+                if ($carrier->min_total > 0 && ($carrier->min_total > $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING))) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }
+
+                if ($carrier->max_total > 0 && ($carrier->max_total < $cart->getOrderTotal(true, Cart::BOTH_WITHOUT_SHIPPING))) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }		    
+		    
+                if ($carrier->min_weight > 0 && ($carrier->min_weight > $product->weight * $cartQuantity || $carrier->min_weight > $cartWeight)) {
+                    $error[$carrier->id] = static::SHIPPING_WEIGHT_EXCEPTION;
+                    unset($carrierList[$key]);
+                }		    
+		    
                 if ($carrier->max_weight > 0 && ($carrier->max_weight < $product->weight * $cartQuantity || $carrier->max_weight < $cartWeight)) {
                     $error[$carrier->id] = static::SHIPPING_WEIGHT_EXCEPTION;
                     unset($carrierList[$key]);

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -588,6 +588,27 @@ class AdminCarrierWizardControllerCore extends AdminController
                     ],
                     [
                         'type'     => 'text',
+                        'label'    => sprintf($this->l('Minimum order value (%s)'), Configuration::get('PS_CURRENCY_DEFAULT')), //* needs edit to show the currency sign
+                        'name'     => 'min_total',
+                        'required' => false,
+                        'hint'     => $this->l('Minimum order value without shipping managed by this carrier. Set the value to "0", or leave this field blank to ignore.'),
+                    ],
+                    [
+                        'type'     => 'text',
+                        'label'    => sprintf($this->l('Maximum order value (%s)'), Configuration::get('PS_CURRENCY_DEFAULT')), //* needs edit to show the currency sign
+                        'name'     => 'max_total',
+                        'required' => false,
+                        'hint'     => $this->l('Maximum order value without shipping managed by this carrier. Set the value to "0", or leave this field blank to ignore.'),
+                    ],
+                    [
+                        'type'     => 'text',
+                        'label'    => sprintf($this->l('Minimum package weight (%s)'), Configuration::get('PS_WEIGHT_UNIT')),
+                        'name'     => 'min_weight',
+                        'required' => false,
+                        'hint'     => $this->l('Minimum weight managed by this carrier. Set the value to "0", or leave this field blank to ignore.'),
+                    ],
+                    [
+                        'type'     => 'text',
                         'label'    => sprintf($this->l('Maximum package weight (%s)'), Configuration::get('PS_WEIGHT_UNIT')),
                         'name'     => 'max_weight',
                         'required' => false,
@@ -638,6 +659,9 @@ class AdminCarrierWizardControllerCore extends AdminController
             'max_height'     => $this->getFieldValue($carrier, 'max_height'),
             'max_width'      => $this->getFieldValue($carrier, 'max_width'),
             'max_depth'      => $this->getFieldValue($carrier, 'max_depth'),
+            'min_total'     => $this->getFieldValue($carrier, 'min_total'),
+            'max_total'     => $this->getFieldValue($carrier, 'max_total'),
+            'min_weight'     => $this->getFieldValue($carrier, 'min_weight'),
             'max_weight'     => $this->getFieldValue($carrier, 'max_weight'),
             'group'          => $this->getFieldValue($carrier, 'group'),
         ];
@@ -1137,7 +1161,7 @@ class AdminCarrierWizardControllerCore extends AdminController
         $stepFields = [
             1 => ['name', 'delay', 'grade', 'url'],
             2 => ['is_free', 'id_tax_rules_group', 'shipping_handling', 'shipping_method', 'range_behavior'],
-            3 => ['range_behavior', 'max_height', 'max_width', 'max_depth', 'max_weight'],
+            3 => ['range_behavior', 'max_height', 'max_width', 'max_depth', 'min_total', 'max_total', 'min_weight', 'max_weight'],
             4 => [],
         ];
         if (Shop::isFeatureActive()) {

--- a/controllers/admin/AdminCarriersController.php
+++ b/controllers/admin/AdminCarriersController.php
@@ -384,6 +384,27 @@ class AdminCarriersControllerCore extends AdminController
                 ],
                 [
                     'type'     => 'text',
+                    'label'    => $this->l('Minimum order value'),
+                    'name'     => 'min_total',
+                    'required' => false,
+                    'hint'     => $this->l('Minimum order value without shipping managed by this carrier. Set the value to "0," or leave this field blank to ignore.'),
+                ],
+                [
+                    'type'     => 'text',
+                    'label'    => $this->l('Maximum order value'),
+                    'name'     => 'max_total',
+                    'required' => false,
+                    'hint'     => $this->l('Maximum order value without shipping managed by this carrier. Set the value to "0," or leave this field blank to ignore.'),
+                ],
+                [
+                    'type'     => 'text',
+                    'label'    => $this->l('Minimum package weight'),
+                    'name'     => 'min_weight',
+                    'required' => false,
+                    'hint'     => $this->l('Minimum weight managed by this carrier. Set the value to "0," or leave this field blank to ignore.'),
+                ],
+                [
+                    'type'     => 'text',
                     'label'    => $this->l('Maximum package weight'),
                     'name'     => 'max_weight',
                     'required' => false,


### PR DESCRIPTION
Extending carrier options on tab 2-Shipping locations and costs:
- minimum-weight
- minimum-order-value
- maximum-order-value


The 3 new _carrier sql collumns should be added like the one for max_weight
- min_total
- max_total
- min_weight


Also there is en error for not showing Currency symbol on my added min_total and max_total, as my knowledge does not reach that high to make that work by myself.