### PR TITLE
Fixed wrong robots.txt rule created and blocing all controllers

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -1002,7 +1002,8 @@ class AdminMetaControllerCore extends AdminController
 					  AND TRIM(IFNULL(ml.url_rewrite, "")) != ""';
             if ($results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql)) {
                 foreach ($results as $row) {
-                    $tab['Files'][$row['iso_code']][] = $row['url_rewrite'];
+                    if(!empty($row['url_rewrite']))
+                        $tab['Files'][$row['iso_code']][] = $row['url_rewrite'];
                 }
             }
         }


### PR DESCRIPTION
Even in default installation 'statistics' meta entry has empty rewrite. producing `Disallow /en/` which blocks every url including main page