### PR TITLE
There is alot of modules that acually use this path for google

### DIFF
--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -980,7 +980,7 @@ class AdminMetaControllerCore extends AdminController
         $tab['Allow'] = ['*/modules/*.css', '*/modules/*.js'];
 
         // Directories
-        $tab['Directories'] = ['classes/', 'config/', 'download/', 'mails/', 'modules/', 'translations/', 'tools/'];
+        $tab['Directories'] = ['classes/', 'config/', 'download/', 'mails/', 'translations/', 'tools/'];
 
         // Files
         $disallowControllers = [


### PR DESCRIPTION
I create it as separate pull request as I'm aware you may not accept it and tell me to override robots txt while it regenerates if my modules needs to be accessed this way

However, there are modules that do work on TB, but sitemap does not work, and google says its it cannot reach path (google does not state its a robots txt problem) So merchant may tear his hair out of his head why it does not work. May not be proper solution, but may save save lots of frustration if module is still not intended and tested on TB

Google cannot access sitemap generators, feed generators etc. Google should not be blocked from accessing modules dir