### PR TITLE
Fixing problem of dynamically created select of order states

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -62,7 +62,7 @@
 			wait: 750,
 			callback: function(){ searchProducts(); }
 		});
-		$('#payment_module_name').change(function() {
+		$('#summary_part').on('change', '#payment_module_name', function(){
 			var id_order_state = defaults_order_state[this.value];
 			if (typeof(id_order_state) == 'undefined')
 				id_order_state = defaults_order_state['other'];


### PR DESCRIPTION
When you create an order in BO and change the payment method, the order state select isn't updating to the default value. The reason: This select gets updated dynamically with: 
`('#payment_module_name').replaceWith(data.view)`

That's why .change is not working...

In case you wonder, what this default order states are: it was never implemented completly, but in general it's a good idea. Here you see the hardcoded part: https://github.com/thirtybees/thirtybees/blob/1.1.x/controllers/admin/AdminOrdersController.php#L287