### PR TITLE
Allowing the usage of $order Object in actionOrderStatusUpdate Hook.

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -115,8 +115,8 @@ class OrderHistoryCore extends ObjectModel
             Hook::exec('actionPaymentConfirmation', ['id_order' => (int) $order->id], null, false, true, false, $order->id_shop);
         }
 
-        // executes hook
-        Hook::exec('actionOrderStatusUpdate', ['newOrderStatus' => $newOs, 'id_order' => (int) $order->id], null, false, true, false, $order->id_shop);
+        // executes hook (param $order available since 1.1.x)
+        Hook::exec('actionOrderStatusUpdate', ['newOrderStatus' => $newOs, 'id_order' => (int) $order->id, 'order' => $order], null, false, true, false, $order->id_shop);
 
         if (Validate::isLoadedObject($order) && ($newOs instanceof OrderState)) {
             $context = Context::getContext();


### PR DESCRIPTION
When you work with the hook actionOrderStatusUpdate, you often have to read or even edit the $order Object as well. So it's logically to give this object as a $param into the hook execution. 

Right now it's not possible to edit the $order object. Even when you go for "new Order($id_order)", because after the hook is executed, the order gets overwritten again.

Note: Don't forget to adjust the comment, when (version) $order was introduced.