### PR TITLE
Using right ids in getModuleNameById condition

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1741,7 +1741,7 @@ abstract class ModuleCore
     {
         $map = static::getModulesNameToIdMap();
         foreach ($map as $moduleName => $id) {
-            if ($moduleId === $moduleId) {
+            if ($moduleId === $id) {
                 return $moduleName;
             }
         }


### PR DESCRIPTION
AdminControllers of modules may not display in back office menu due to the condition of the getModuleNameById function which always return the first module name encountered in the map array.
If the returned module is no longer in the filesystem, the isEnabledForShops function of Module class return false