### PR TITLE
Improve Product.php MySQL 8 compatibility

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5646,7 +5646,8 @@ class ProductCore extends ObjectModel
 				FROM `'._DB_PREFIX_.'product_attribute` pa
 				'.Shop::addSqlAssociation('product_attribute', 'pa').'
 				WHERE pa.`id_product` = '.(int) $this->id.'
-				GROUP BY pa.`id_product_attribute`'
+				GROUP BY pa.`id_product_attribute`
+				ORDER BY pa.`id_product_attribute`'
         );
 
         if (!$combinations) {
@@ -5666,7 +5667,8 @@ class ProductCore extends ObjectModel
 				LEFT JOIN `'._DB_PREFIX_.'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = '.(int) $idLang.')
 				LEFT JOIN `'._DB_PREFIX_.'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = '.(int) $idLang.')
 				WHERE pac.id_product_attribute IN ('.implode(',', $productAttributes).')
-				GROUP BY pac.id_product_attribute'
+				GROUP BY pac.id_product_attribute
+			   	ORDER BY pac.id_product_attribute'
         );
 
         foreach ($lang as $k => $row) {


### PR DESCRIPTION
In MySQL 8 implicit and explicit sorting for GROUP BY is removed. This code relies on that sorting, so it should be improved by adding explicit ORDER BY. It does not break backward compatibility.

More about implicit and explicit sorting for GROUP BY removal: https://mysqlserverteam.com/removal-of-implicit-and-explicit-sorting-for-group-by/

For MySQL there is a bug in back office caused by this code - on product's Quantity tab, names of combinations are wrong, causing the shop administrator to set quantities for wrong combinations.