### PR TITLE
Spaces in image file names

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3189,11 +3189,11 @@ class ToolsCore
                         fwrite($write_fd, "# Legacy image rewrites\n");
                         fwrite($write_fd, $mediaDomains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4$5.jpg [L]'."\n");
+                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-\s]*)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4$5.jpg [L]'."\n");
 
                         fwrite($write_fd, $mediaDomains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4$5.webp [L]'."\n");
+                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-\s]*)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4$5.webp [L]'."\n");
 
                         fwrite($write_fd, $mediaDomains);
                         fwrite($write_fd, $domain_rewrite_cond);
@@ -3215,27 +3215,27 @@ class ToolsCore
                         $img_name .= '$'.$j;
                         fwrite($write_fd, $mediaDomains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).'$'.($j + 2).".jpg [L]\n");
+                        fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-\s]*)?(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).'$'.($j + 2).".jpg [L]\n");
 
                         fwrite($write_fd, $mediaDomains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).'$'.($j + 2).".webp [L]\n");
+                        fwrite($write_fd, 'RewriteRule ^'.str_repeat('([0-9])', $i).'(\-[_a-zA-Z0-9-\s]*)?(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/p/'.$img_path.$img_name.'$'.($j + 1).'$'.($j + 2).".webp [L]\n");
                     }
                     fwrite($write_fd, $mediaDomains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3$4.jpg [L]'."\n");
+                    fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-\s]*)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3$4.jpg [L]'."\n");
 
                     fwrite($write_fd, $mediaDomains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/c/$1$2$3$4.webp [L]'."\n");
+                    fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-\s]*)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/c/$1$2$3$4.webp [L]'."\n");
 
                     fwrite($write_fd, $mediaDomains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3.jpg [L]'."\n");
+                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-\s]+)(-[0-9]+)?/.+?([2-4]x)?\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3.jpg [L]'."\n");
 
                     fwrite($write_fd, $mediaDomains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/c/$1$2$3.webp [L]'."\n");
+                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-\s]+)(-[0-9]+)?/.+?([2-4]x)?\.webp$ %{ENV:REWRITEBASE}img/c/$1$2$3.webp [L]'."\n");
                 }
 
                 fwrite($write_fd, "\n# AlphaImageLoader for IE and fancybox\n");


### PR DESCRIPTION
I recently made a theme that somehow keeps ending up with spaces in the image names. 

Currently, the htaccess file does not support this. 

Adding `\s` to the RewriteRules where it expects the theme name allows for this to work correctly.