### PR TITLE
Preserve unicode chars on json encode

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -596,7 +596,7 @@ class AdminStoresControllerCore extends AdminController
             for ($i = 1; $i < 8; $i++) {
                 $_POST['hours'][] .= Tools::getValue('hours_'.(int) $i);
             }
-            $_POST['hours'] = json_encode($_POST['hours']);
+            $_POST['hours'] = json_encode($_POST['hours'], JSON_UNESCAPED_UNICODE);
         }
 
         if (!count($this->errors)) {


### PR DESCRIPTION
When saving hours of operation in Store, all hours array are combined into json encoded value. this cause the unicode chars to get lost.
@getdatakick Please confirm that this is safe, because I am not a php developer.