### PR TITLE
Fix: Query for Country::getCountriesByIdShop

### DIFF
--- a/classes/Country.php
+++ b/classes/Country.php
@@ -126,8 +126,8 @@ class CountryCore extends ObjectModel
             (new DbQuery())
                 ->select('*')
                 ->from('country', 'c')
-                ->leftJoin('country_shop', 'cs', 'cs.`id_country` = c.`id_country` AND cs.`id_shop` = '.(int) $idShop.' AND cs.`id_lang` = '.(int) $idLang)
-                ->leftJoin('country_lang', 'cl', 'cl.`id_country` = c.`id_country`')
+                ->leftJoin('country_shop', 'cs', 'cs.`id_country` = c.`id_country` AND cs.`id_shop` = '.(int) $idShop)
+                ->leftJoin('country_lang', 'cl', 'cl.`id_country` = c.`id_country` AND cl.`id_lang` = '.(int) $idLang)
         );
     }
 


### PR DESCRIPTION
The Country_shop table cannot be filtered on a nonexistent id_lang column.
Moved filtering by id_lang to table country_lang.
This issue prevents a clean installation of the Polish DPD module.