### PR TITLE
Fixes for NL tax rules

### DIFF
--- a/localization/nl.xml
+++ b/localization/nl.xml
@@ -76,7 +76,7 @@
       <taxRule iso_code_country="fi" id_tax="1" />
       <taxRule iso_code_country="se" id_tax="1" />
       <taxRule iso_code_country="gb" id_tax="1" />
-      <taxRule iso_code_country="hr" id_tax="2" />
+      <taxRule iso_code_country="hr" id_tax="1" />
     </taxRulesGroup>
     <taxRulesGroup name="NL Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2" />

--- a/localization/nl.xml
+++ b/localization/nl.xml
@@ -78,7 +78,7 @@
       <taxRule iso_code_country="gb" id_tax="1" />
       <taxRule iso_code_country="hr" id_tax="2" />
     </taxRulesGroup>
-    <taxRulesGroup name="NL Reduced Rate (6%)">
+    <taxRulesGroup name="NL Reduced Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2" />
       <taxRule iso_code_country="bg" id_tax="2" />
       <taxRule iso_code_country="cz" id_tax="2" />
@@ -108,7 +108,7 @@
       <taxRule iso_code_country="gb" id_tax="2" />
       <taxRule iso_code_country="hr" id_tax="2" />
     </taxRulesGroup>
-    <taxRulesGroup name="NL Foodstuff Rate (6%)">
+    <taxRulesGroup name="NL Foodstuff Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2" />
       <taxRule iso_code_country="bg" id_tax="2" />
       <taxRule iso_code_country="cz" id_tax="2" />
@@ -138,7 +138,7 @@
       <taxRule iso_code_country="gb" id_tax="2" />
       <taxRule iso_code_country="hr" id_tax="2" />
     </taxRulesGroup>
-    <taxRulesGroup name="NL Books Rate (6%)">
+    <taxRulesGroup name="NL Books Rate (9%)">
       <taxRule iso_code_country="be" id_tax="2" />
       <taxRule iso_code_country="bg" id_tax="2" />
       <taxRule iso_code_country="cz" id_tax="2" />


### PR DESCRIPTION
In commit eab245087f107dc3948e9161f2b7d80fbf6565c1, the Dutch VAT rate was changed from 6% to 9%, but the name of the tax rules weren't changed.

The tax rate for Croatia in the "NL Standard Rate (21%)" tax rule was also accidentally set to the 9% tax rate instead of the 21% tax rate.