### PR TITLE
Adding root_dir as global smarty variable

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1724,6 +1724,7 @@ class FrontControllerCore extends Controller
                 'base_uri'            => $protocolContent.Tools::getHttpHost().__PS_BASE_URI__.(!Configuration::get('PS_REWRITING_SETTINGS') ? 'index.php' : ''),
                 'tpl_dir'             => _PS_THEME_DIR_,
                 'tpl_uri'             => _THEME_DIR_,
+                'root_dir'            => _PS_ROOT_DIR_,
                 'modules_dir'         => _MODULE_DIR_,
                 'mail_dir'            => _MAIL_DIR_,
                 'lang_iso'            => $this->context->language->iso_code,


### PR DESCRIPTION
If you want to include a tpl file in another tpl file you need to specify the root path. Normally you can work with _PS_THEME_DIR. But in some occasions you might want to include a tpl file from a module. At least for me it's not clear how to do that easily.

Instead of adding all kind of _PS_ vars, I prefered to just add the _PS_ROOT_DIR_. This allows usage like {$root_dir}{$modules_dir}.