### PR TITLE
Order detail: useless dash with customer name necessary in B2B mode only

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -580,7 +580,7 @@
             {l s='Customer'}
             <span class="badge">
 							<a href="?tab=AdminCustomers&amp;id_customer={$customer->id}&amp;viewcustomer&amp;token={getAdminToken tab='AdminCustomers'}">
-								{if Configuration::get('PS_B2B_ENABLE')}{$customer->company} - {/if}
+								{if Configuration::get('PS_B2B_ENABLE') && $customer->company}{$customer->company} - {/if}
                 {$gender->name|escape:'html':'UTF-8'}
                 {$customer->firstname}
                 {$customer->lastname}


### PR DESCRIPTION
BO: Orders > Order detail shows on right side customer block with name placed in blue badge. Before name is dash which should be visible in B2B mode active only, as it represents separation mark between name and company of customer. So when B2B mode is off, this dash is useles
![Admin Orders Order - B2B - bug](https://user-images.githubusercontent.com/57491379/159290548-b59dc1f0-49e4-4f8a-85be-2b88c0fdbc65.png)
s