### PR TITLE
Allow usage of order object in $params

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -366,7 +366,7 @@ class OrderHistoryCore extends ObjectModel
         }
 
         // executes hook
-        Hook::exec('actionOrderStatusPostUpdate', ['newOrderStatus' => $newOs, 'id_order' => (int) $order->id], null, false, true, false, $order->id_shop);
+        Hook::exec('actionOrderStatusPostUpdate', ['newOrderStatus' => $newOs, 'id_order' => (int) $order->id, 'order' => $order], null, false, true, false, $order->id_shop);
 
         ShopUrl::resetMainDomainCache();
     }


### PR DESCRIPTION
Same idea as in https://github.com/thirtybees/thirtybees/pull/1255. 

Sorry I didn't know, that there is hook before the actual orderStatus update and one afterwards.