### PR TITLE
Fixing issue 1035: reference name conflict

### DIFF
--- a/controllers/admin/AdminSupplyOrdersController.php
+++ b/controllers/admin/AdminSupplyOrdersController.php
@@ -1193,6 +1193,9 @@ class AdminSupplyOrdersControllerCore extends AdminController
             // gets the reference
             $ref = pSQL(Tools::getValue('reference'));
 
+            // Make sure the product reference won't be overridden by the supplier reference (both columns are just called "reference")
+            unset($_POST['reference']);
+
             if (Tools::getValue('id_supply_order') != 0 && SupplyOrder::getReferenceById((int) Tools::getValue('id_supply_order')) != $ref) {
                 if ((int) SupplyOrder::exists($ref) != 0) {
                     $this->errors[] = Tools::displayError('The reference has to be unique.');
@@ -1428,6 +1431,12 @@ class AdminSupplyOrdersControllerCore extends AdminController
         }
 
         if ((!count($this->errors) && $this->is_editing_order) || !$this->is_editing_order) {
+
+            // Make sure that the supply order reference is saved (it was unset above)
+            if (isset($ref) && $ref) {
+                $_POST['reference'] = $ref;
+            }
+
             parent::postProcess();
         }
     }


### PR DESCRIPTION
I am very confident, that I finally could solve issue #1035 in a more or less clean way. 

It's problematic to use generic field name like "reference" in a form that works with multiple objects. In this case SupplyOrder & SupplyOrderDetail objects. 

In objectModel->validateController there is line: https://github.com/thirtybees/thirtybees/blob/97f3f33f3af9d972ff92745757cc34ee3ae0ef48/classes/ObjectModel.php#L1331

It will always override the $supplyOrderDetail->reference with Tools::getValue('reference'). But Tools::getValue('reference') is actually the $supplyOrder->reference. 

IMO it would be quite risky/ugly to change the generic validateController. Thats why I unset the $_POST value till the $supplyOrderDetails objects were saved and add it again, when the $supplyOrder object is saved.

Note: renaming the reference field is not really simpler. You will then need to "hack" postProcess function as well. Otherwise, $supplyOrder->reference would be empty.