### PR TITLE
Fix issue 1354 (always using same product_mini path_format)

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -948,6 +948,10 @@ class ImageCore extends ObjectModel
         $filesToDelete[] = _PS_TMP_IMG_DIR_.'product_'.$this->id_product.'.'.$format;
         $filesToDelete[] = _PS_TMP_IMG_DIR_.'product_mini_'.$this->id_product.'.'.$format;
 
+        foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+            $filesToDelete[] = _PS_TMP_IMG_DIR_.'product_mini_'.$this->id_product.'_'.$id_shop.'.'.$format;
+        }
+
         // perform delete
         $result = true;
         foreach ($filesToDelete as $file) {

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -124,7 +124,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
         if (Configuration::get('PS_PDF_IMG_DELIVERY')) {
             foreach ($orderDetails as &$orderDetail) {
                 if ($orderDetail['image'] instanceof Image) {
-                    $name = 'product_mini_'.(int) $orderDetail['product_id'].(isset($orderDetail['product_attribute_id']) ? '_'.(int) $orderDetail['product_attribute_id'] : '').'.jpg';
+                    $name = 'product_mini_'.(int) $orderDetail['product_id'].'_'.$this->order->id_shop.'.jpg';
                     $path = _PS_PROD_IMG_DIR_.$orderDetail['image']->getExistingImgPath().'.jpg';
 
                     $orderDetail['image_tag'] = preg_replace(

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -158,7 +158,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
         if (Configuration::get('PS_PDF_IMG_INVOICE')) {
             foreach ($orderDetails as &$orderDetail) {
                 if ($orderDetail['image'] instanceof Image) {
-                    $name = 'product_mini_'.(int) $orderDetail['product_id'].(isset($orderDetail['product_attribute_id']) ? '_'.(int) $orderDetail['product_attribute_id'] : '').'.jpg';
+                    $name = 'product_mini_'.(int) $orderDetail['product_id'].'_'.$this->order->id_shop.'.jpg';
                     $path = _PS_PROD_IMG_DIR_.$orderDetail['image']->getExistingImgPath().'.jpg';
 
                     $orderDetail['image_tag'] = preg_replace(

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -330,11 +330,11 @@ class AdminCartsControllerCore extends AdminController
                 );
             }
 
-            $product['qty_in_stock'] = StockAvailable::getQuantityAvailableByProduct($product['id_product'], isset($product['id_product_attribute']) ? $product['id_product_attribute'] : null, (int) $idShop);
+            $product['qty_in_stock'] = StockAvailable::getQuantityAvailableByProduct($product['id_product'], isset($product['id_product_attribute']) ? $product['id_product_attribute'] : null, $idShop);
 
             if ($image) {
                 $imageProduct = new Image($image);
-                $product['image'] = ImageManager::thumbnail(_PS_IMG_DIR_.'p/'.$imageProduct->getExistingImgPath().'.jpg', 'product_mini_'.(int) $product['id_product'].(isset($product['id_product_attribute']) ? '_'.(int) $product['id_product_attribute'] : '').'.jpg', 45, 'jpg');
+                $product['image'] = ImageManager::thumbnail(_PS_IMG_DIR_.'p/'.$imageProduct->getExistingImgPath().'.jpg', 'product_mini_'.(int) $product['id_product'].'_'.$idShop.'.jpg', 45);
             } else {
                 $product['image'] = '--';
             }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2201,11 +2201,14 @@ class AdminImportControllerCore extends AdminController
 
                     if ($success) {
                         if ($entity == 'products') {
-                            if (is_file(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $idEntity.'.jpg')) {
-                                unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $idEntity.'.jpg');
+                            @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$idEntity.'.jpg');
+                            if (Shop::getContext()==Shop::CONTEXT_ALL) {
+                                foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                                    @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$idEntity.'_'.$id_shop.'.jpg');
+                                }
                             }
-                            if (is_file(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $idEntity.'_'.(int) Context::getContext()->shop->id.'.jpg')) {
-                                unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $idEntity.'_'.(int) Context::getContext()->shop->id.'.jpg');
+                            else {
+                                @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int)$idEntity.'_'.(int) Context::getContext()->shop->id.'.jpg');
                             }
                         }
                     }

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3338,7 +3338,7 @@ class AdminOrdersControllerCore extends AdminController
 
         foreach ($products as &$product) {
             if ($product['image'] != null) {
-                $name = 'product_mini_'.(int) $product['product_id'].(isset($product['product_attribute_id']) ? '_'.(int) $product['product_attribute_id'] : '').'.jpg';
+                $name = 'product_mini_'.(int) $product['product_id'].'_'.$order->id_shop.'.jpg';
                 // generate image cache, only for back office
                 $product['image_tag'] = ImageManager::thumbnail(_PS_IMG_DIR_.'p/'.$product['image']->getExistingImgPath().'.jpg', $name, 45, 'jpg');
                 if (file_exists(_PS_TMP_IMG_DIR_.$name)) {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -943,7 +943,14 @@ class AdminProductsControllerCore extends AdminController
                 } else {
                     $productId = (int) Tools::getValue('id_product');
                     @unlink(_PS_TMP_IMG_DIR_.'product_'.$productId.'.jpg');
-                    @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$productId.'_'.$this->context->shop->id.'.jpg');
+                    if (Shop::getContext()==Shop::CONTEXT_ALL) {
+                        foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                            @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$productId.'_'.$id_shop.'.jpg');
+                        }
+                    }
+                    else {
+                        @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$productId.'_'.$this->context->shop->id.'.jpg');
+                    }
                     $this->redirect_after = static::$currentIndex.'&id_product='.$image->id_product.'&id_category='.(Tools::getIsset('id_category') ? '&id_category='.(int) Tools::getValue('id_category') : '').'&action=Images&addproduct'.'&token='.$this->token;
                 }
             } elseif (Tools::getIsset('imgPosition') && Tools::getIsset('imgDirection')) {
@@ -1627,8 +1634,16 @@ class AdminProductsControllerCore extends AdminController
         }
         $img->cover = 1;
 
-        @unlink(_PS_TMP_IMG_DIR_.'product_'.(int) $img->id_product.'.jpg');
-        @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $img->id_product.'_'.$this->context->shop->id.'.jpg');
+        @unlink(_PS_TMP_IMG_DIR_.'product_'.$img->id_product.'.jpg');
+
+        if (Shop::getContext()==Shop::CONTEXT_ALL) {
+            foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$img->id_product.'_'.$id_shop.'.jpg');
+            }
+        }
+        else {
+            @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$img->id_product.'_'.$this->context->shop->id.'.jpg');
+        }
 
         if ($img->update()) {
             $this->jsonConfirmation($this->_conf[26]);
@@ -1673,9 +1688,21 @@ class AdminProductsControllerCore extends AdminController
         if (file_exists(_PS_TMP_IMG_DIR_.'product_'.$image->id_product.'.jpg')) {
             $res &= @unlink(_PS_TMP_IMG_DIR_.'product_'.$image->id_product.'.jpg');
         }
-        if (file_exists(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$this->context->shop->id.'.jpg')) {
-            $res &= @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$this->context->shop->id.'.jpg');
+
+        if (Shop::getContext()==Shop::CONTEXT_ALL) {
+            foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                if (file_exists(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$id_shop.'.jpg')) {
+                    $res &= @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$id_shop.'.jpg');
+                }
+            }
         }
+        else {
+            if (file_exists(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$this->context->shop->id.'.jpg')) {
+                $res &= @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$image->id_product.'_'.$this->context->shop->id.'.jpg');
+            }
+        }
+
+
 
         if ($res) {
             $this->jsonConfirmation($this->_conf[7]);
@@ -1722,7 +1749,15 @@ class AdminProductsControllerCore extends AdminController
             return false;
         }
         @unlink(_PS_TMP_IMG_DIR_.'product_'.$product->id.'.jpg');
-        @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$product->id.'_'.$this->context->shop->id.'.jpg');
+
+        if (Shop::getContext()==Shop::CONTEXT_ALL) {
+            foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$product->id.'_'.$id_shop.'.jpg');
+            }
+        }
+        else {
+            @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.$product->id.'_'.$this->context->shop->id.'.jpg');
+        }
 
         return ((isset($idImage) && is_int($idImage) && $idImage) ? $idImage : false);
     }
@@ -5093,7 +5128,16 @@ class AdminProductsControllerCore extends AdminController
                 $file['shops'] = $jsonShops;
 
                 @unlink(_PS_TMP_IMG_DIR_.'product_'.(int) $product->id.'.jpg');
-                @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $product->id.'_'.$this->context->shop->id.'.jpg');
+
+                if (Shop::getContext()==Shop::CONTEXT_ALL) {
+                    foreach (Shop::getCompleteListOfShopsID() as $id_shop) {
+                        @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $product->id.'_'.$id_shop.'.jpg');
+                    }
+                }
+                else {
+                    @unlink(_PS_TMP_IMG_DIR_.'product_mini_'.(int) $product->id.'_'.$this->context->shop->id.'.jpg');
+                }
+
             }
         }
 


### PR DESCRIPTION
I am experiencing this issue https://github.com/thirtybees/thirtybees/issues/1354 since years as well. That's why I tried to fix it.

As you can read in the issue notes: the BO uses different paths. I tried to find all product_mini usages and changed the code to the following format: **product_mini_{$id_product}_{$id_shop}.jpg**.

Why not using id_product_attribute (as some parts of the code did)? Either I am getting it wrong or this makes no sense at all. product_mini is the cover image in a small cached format. There is no way, you could save the cover image related to a product_attribute. You can only save different covers for different shops. Of course one could discuss, if this option should be added, but for now it's simpler to just us the path_format with $id_shop.

Note: This PR should be tested by at least another person. Neither did I test this a lot, nor do I use a lot of product_attributes.