### PR TITLE
Backoffice Order Address Copying

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -718,8 +718,8 @@
                         {l s='Edit'}
                       </a>
 
-                      <div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                      <div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                       </div>
 
                       {if $addresses.delivery->other}
@@ -778,8 +778,8 @@
                       {l s='Edit'}
                     </a>
 
-                    <div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                    <div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                     </div>
 
                     {if $addresses.invoice->other}

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -718,8 +718,8 @@
                         {l s='Edit'}
                       </a>
 
-                      <div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                      <div onclick="copyHighlightedTextInDiv(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                      {displayAddressDetail address=$addresses.delivery newLine='</div><div onclick="copyHighlightedTextInDiv(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                       </div>
 
                       {if $addresses.delivery->other}
@@ -778,8 +778,8 @@
                       {l s='Edit'}
                     </a>
 
-                    <div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboardAndSelect(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                    <div onclick="copyHighlightedTextInDiv(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                    {displayAddressDetail address=$addresses.invoice newLine='</div><div onclick="copyHighlightedTextInDiv(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                     </div>
 
                     {if $addresses.invoice->other}

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -718,8 +718,8 @@
                         {l s='Edit'}
                       </a>
 
-                      <div ondblclick="copyDivTextContentToClipboard(event);">
-                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);">'}
+                      <div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                       </div>
 
                       {if $addresses.delivery->other}
@@ -778,8 +778,8 @@
                       {l s='Edit'}
                     </a>
 
-                    <div ondblclick="copyDivTextContentToClipboard(event);">
-                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);">'}
+                    <div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                     </div>
 
                     {if $addresses.invoice->other}

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -709,11 +709,19 @@
                 <div class="well">
                   <div class="row">
                     <div class="col-sm-6">
+                      <a class="btn btn-default pull-right" style="margin-left: 5px" onclick="copyToClipboard('{displayAddressDetail address=$addresses.delivery newLine='\n'}', event);">
+                        <i class="icon-copy"></i>
+                        {l s='Copy'}
+                      </a>
                       <a class="btn btn-default pull-right" href="?tab=AdminAddresses&amp;id_address={$addresses.delivery->id}&amp;addaddress&amp;realedit=1&amp;id_order={$order->id}&amp;address_type=1&amp;token={getAdminToken tab='AdminAddresses'}&amp;back={$smarty.server.REQUEST_URI|urlencode}">
                         <i class="icon-pencil"></i>
                         {l s='Edit'}
                       </a>
-                      {displayAddressDetail address=$addresses.delivery newLine='<br />'}
+
+                      <div ondblclick="copyDivTextContentToClipboard(event);">
+                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);">'}
+                      </div>
+
                       {if $addresses.delivery->other}
                         <hr/>
                         {$addresses.delivery->other}
@@ -761,11 +769,19 @@
               <div class="well">
                 <div class="row">
                   <div class="col-sm-6">
+                    <a class="btn btn-default pull-right" style="margin-left: 5px" onclick="copyToClipboard('{displayAddressDetail address=$addresses.invoice newLine='\n'}', event);">
+                      <i class="icon-copy"></i>
+                      {l s='Copy'}
+                    </a>
                     <a class="btn btn-default pull-right" href="?tab=AdminAddresses&amp;id_address={$addresses.invoice->id}&amp;addaddress&amp;realedit=1&amp;id_order={$order->id}&amp;address_type=2&amp;back={$smarty.server.REQUEST_URI|urlencode}&amp;token={getAdminToken tab='AdminAddresses'}">
                       <i class="icon-pencil"></i>
                       {l s='Edit'}
                     </a>
-                    {displayAddressDetail address=$addresses.invoice newLine='<br />'}
+
+                    <div ondblclick="copyDivTextContentToClipboard(event);">
+                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);">'}
+                    </div>
+
                     {if $addresses.invoice->other}
                       <hr/>
                       {$addresses.invoice->other}

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -718,8 +718,8 @@
                         {l s='Edit'}
                       </a>
 
-                      <div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                      <div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                      {displayAddressDetail address=$addresses.delivery newLine='</div><div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                       </div>
 
                       {if $addresses.delivery->other}
@@ -778,8 +778,8 @@
                       {l s='Edit'}
                     </a>
 
-                    <div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
-                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
+                    <div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="{l s='Copied!'}" data-trigger="manual">
+                    {displayAddressDetail address=$addresses.invoice newLine='</div><div ondblclick="copyDivTextContentToClipboard(event, true);" data-placement="left" data-content="Copied!" data-trigger="manual">'}
                     </div>
 
                     {if $addresses.invoice->other}

--- a/js/tools.js
+++ b/js/tools.js
@@ -711,9 +711,6 @@ function executeFunctionByName(functionName, args, context=window) {
 
 function copyToClipboard(data, e)
 {
-  if (e != undefined)
-    e.preventDefault();
-
   try {
     if (navigator.clipboardData)
       navigator.clipboardData.setData('Text', data);
@@ -726,36 +723,34 @@ function copyToClipboard(data, e)
   }
 }
 
-function copyDivTextContentToClipboard(e, popover)
-{
-  copyToClipboard(e.target.textContent.trim(), e);
+var copyHighlightedTextInDiv_popoverTimeout = null;
 
-  if (popover)
-  {
-    $(e.target).popover().popover('show');
-    setTimeout(() => { $(e.target).popover('hide'); }, 1000);
-  }
-}
-
-function copyDivTextContentToClipboardAndSelect(e, popover)
+function copyHighlightedTextInDiv(e, popover)
 {
-  copyDivTextContentToClipboard(e, popover);
+  if (!e || e.detail < 2)
+    return;
+
+  e.preventDefault();
 
   try {
-    if (document.selection) {
-      var range = document.body.createTextRange();
-      range.moveToElementText(e.target);
-      range.select();
-    } else if (window.getSelection) {
-      var range = document.createRange();
-      range.selectNode(e.target);
-      window.getSelection().removeAllRanges();
-      window.getSelection().addRange(range);
+    let selection = window.getSelection().toString().trim();
+
+    copyToClipboard(selection, e);
+
+    if (popover)
+    {
+      if (copyHighlightedTextInDiv_popoverTimeout != null)
+        clearTimeout(copyHighlightedTextInDiv_popoverTimeout);
+
+      copyHighlightedTextInDiv_popoverTimeout = setTimeout(() => {
+        $(e.target).popover().popover('show');
+        setTimeout(() => { $(e.target).popover('hide'); }, 1000);
+        copyHighlightedTextInDiv_popoverTimeout = null;
+      }, 250);
     }
   }
-  catch (e)
-  {
-    console.error("Failed to select div");
+  catch (e) {
+    console.error("Failed to copy highlighted text in div");
   }
 }
 

--- a/js/tools.js
+++ b/js/tools.js
@@ -28,7 +28,7 @@
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 
- function formatedNumberToFloat(price, currencyFormat, currencySign) {
+function formatedNumberToFloat(price, currencyFormat, currencySign) {
   price = price.replace(currencySign, '').replace(/ /g, '');
 
   switch (currencyFormat) {

--- a/js/tools.js
+++ b/js/tools.js
@@ -726,9 +726,15 @@ function copyToClipboard(data, e)
   }
 }
 
-function copyDivTextContentToClipboard(e)
+function copyDivTextContentToClipboard(e, popover)
 {
   copyToClipboard(e.target.textContent.trim(), e);
+
+  if (popover)
+  {
+    $(e.target).popover().popover('show');
+    setTimeout(() => { $(e.target).popover('hide'); }, 1000);
+  }
 }
 
 $(document).ready(function () {

--- a/js/tools.js
+++ b/js/tools.js
@@ -709,6 +709,28 @@ function executeFunctionByName(functionName, args, context=window) {
   return context[func].apply(context, args);
 }
 
+function copyToClipboard(data, e)
+{
+  if (e != undefined)
+    e.preventDefault();
+
+  try {
+    if (navigator.clipboardData)
+      navigator.clipboardData.setData('Text', data);
+    else
+      navigator.clipboard.writeText(data);
+  }
+  catch (e)
+  {
+    console.error("Failed to write to clipboard: " + data);
+  }
+}
+
+function copyDivTextContentToClipboard(e)
+{
+  copyToClipboard(e.target.textContent.trim(), e);
+}
+
 $(document).ready(function () {
   // Hide all elements with .hideOnSubmit class when parent form is submit
   $('form').submit(function () {

--- a/js/tools.js
+++ b/js/tools.js
@@ -28,7 +28,7 @@
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 
-function formatedNumberToFloat(price, currencyFormat, currencySign) {
+ function formatedNumberToFloat(price, currencyFormat, currencySign) {
   price = price.replace(currencySign, '').replace(/ /g, '');
 
   switch (currencyFormat) {
@@ -80,7 +80,9 @@ function formatCurrency(price, currencyFormat, currencySign, currencyBlank) {
   // Really? It's used quite a lot.
   //console.log('Deprecated with v1.1.0. Use displayPrice() directly.');
 
-  return displayPrice(price, currencyFormat, currencySign, currencyBlank);
+  var formattedPrice = displayPrice(price, currencyFormat, currencySign, currencyBlank);
+  formattedPrice = formattedPrice.replace(currencySign + String.fromCharCode(160), currencySign);
+  return formattedPrice;
 }
 
 /*
@@ -102,12 +104,22 @@ function displayPrice(price, currencyFormat, currencySign, currencyBlank) {
     price = 0;
   }
 
-  if (typeof window['currencyFormatters'] !== 'undefined' && window.currencyFormatters[currency]) {
-    var formatter = window.currencyFormatters[currency];
-    var val = executeFunctionByName(formatter, [price, currencyFormat, currencySign, currencyBlank, priceDisplayPrecision]);
-    if (typeof val === 'string' || val instanceof String) {
-      return val;
+  if (typeof window.currencyModes[currency] !== 'undefined' && window.currencyModes[currency]) {
+    price = ps_round(price, priceDisplayPrecision);
+    var locale = document.documentElement.lang;
+    if (locale.length === 5) {
+      locale = locale.substring(0, 2).toLowerCase() + '-' + locale.substring(3, 5).toUpperCase();
+    } else if (typeof window.full_language_code !== 'undefined' && window.full_language_code.length === 5) {
+      locale = window.full_language_code.substring(0, 2).toLowerCase() + '-' + window.full_language_code.substring(3, 5).toUpperCase();
+    } else if (getBrowserLocale().length === 5) {
+      locale = getBrowserLocale().substring(0, 2).toLowerCase() + '-' + getBrowserLocale().substring(3, 5).toUpperCase();
     }
+
+    // format number as an USD currency in specific locale, and then replace USD symbol with currencySign
+    return price
+     .toLocaleString(locale, { style: 'currency', currency: 'USD', currencyDisplay: 'code' })
+     .replace('USD', currencySign || '')
+     .trim();
   }
 
   var blank = '';
@@ -692,23 +704,6 @@ function getBrowserLocale() {
   return navigator.language;
 }
 
-function executeFunctionByName(functionName, args, context=window) {
-  var namespaces = functionName.split(".");
-  var func = namespaces.pop();
-  for (var i = 0; i < namespaces.length; i++) {
-    if (typeof context[namespaces[i]] == "undefined") {
-      console.error("Function " + functionName + " not found, context "+namespaces[i] + " does not exist");
-      return null;
-    }
-    context = context[namespaces[i]];
-  }
-  if (typeof context[func] == "undefined") {
-    console.error("Function " + func + " not found");
-    return null;
-  }
-  return context[func].apply(context, args);
-}
-
 function copyToClipboard(data, e)
 {
   if (e != undefined)
@@ -737,7 +732,30 @@ function copyDivTextContentToClipboard(e, popover)
   }
 }
 
+function copyDivTextContentToClipboardAndSelect(e, popover)
+{
+  copyDivTextContentToClipboard(e, popover);
+
+  try {
+    if (document.selection) {
+      var range = document.body.createTextRange();
+      range.moveToElementText(e.target);
+      range.select();
+    } else if (window.getSelection) {
+      var range = document.createRange();
+      range.selectNode(e.target);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+    }
+  }
+  catch (e)
+  {
+    console.error("Failed to select div");
+  }
+}
+
 $(document).ready(function () {
+
   // Hide all elements with .hideOnSubmit class when parent form is submit
   $('form').submit(function () {
     $(this).find('.hideOnSubmit').hide();


### PR DESCRIPTION
Added a button in the back office for copying the entire address separated by `\n`

Double clicking each line highlights a word (browser dependent) and it will copy only what is highlighted. Triple clicking highlights the entire line (browser dependent) and again will only copy what is highlighted.

This allows you to quickly copy the entire line or just part of the line (example, just the postal code).

![image](https://user-images.githubusercontent.com/8886769/162477546-391135d4-5073-4357-ae57-6e21fd053512.png)

There are also now some helpful functions for copying stuff to the clipboard.

For Issue #1413 