### PR TITLE
Fixing and improving icons on HelperList in BO

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -105,7 +105,7 @@
 							{if isset($tr[$key]['class'])}
 								<i class="{$tr[$key]['class']}"></i>
 							{else}
-								<img src="../img/admin/{$tr[$key]['src']}" alt="{$tr[$key]['alt']}" title="{$tr[$key]['alt']}" />
+								<img src="{$tr[$key]['src']}" alt="{$tr[$key]['alt']}" title="{$tr[$key]['alt']}" {if isset($tr[$key]['width'])}width="{$tr[$key]['width']}"{/if} {if isset($tr[$key]['height'])}height="{$tr[$key]['height']}"{/if} />
 							{/if}
 						{/if}
 					{elseif isset($params.type) && $params.type == 'price'}

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -550,7 +550,7 @@ class HelperListCore extends Helper
                     }
                     // Check if given src icon doesn't exit, but exits in admin folder
                     if (isset($this->_list[$index][$key]['src'])) {
-                        if (!file_exists($this->_list[$index][$key]['src']) && file_exists(_PS_IMG_DIR_.'admin/'.$this->_list[$index][$key]['src'])) {
+                        if (!file_exists(dirname(__FILE__).$this->_list[$index][$key]['src']) && file_exists(_PS_IMG_DIR_.'admin/'.$this->_list[$index][$key]['src'])) {
                             $this->_list[$index][$key]['src'] =_PS_ADMIN_IMG_.$this->_list[$index][$key]['src'];
                         }
                     }

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -548,6 +548,12 @@ class HelperListCore extends Helper
                     } elseif (isset($params['icon'][$tr[$key]])) {
                         $this->_list[$index][$key] = $params['icon'][$tr[$key]];
                     }
+                    // Check if given src icon doesn't exit, but exits in admin folder
+                    if (isset($this->_list[$index][$key]['src'])) {
+                        if (!file_exists($this->_list[$index][$key]['src']) && file_exists(_PS_IMG_DIR_.'admin/'.$this->_list[$index][$key]['src'])) {
+                            $this->_list[$index][$key]['src'] =_PS_ADMIN_IMG_.$this->_list[$index][$key]['src'];
+                        }
+                    }
                 } elseif (isset($params['type']) && $params['type'] == 'float') {
                     $this->_list[$index][$key] = rtrim(rtrim($tr[$key], '0'), '.');
                 } elseif (isset($tr[$key])) {

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -118,7 +118,7 @@ class AdminCartsControllerCore extends AdminController
                 'type'         => 'bool',
                 'havingFilter' => true,
                 'class'        => 'fixed-width-xs',
-                'icon'         => [0 => 'icon-', 1 => 'icon-user'],
+                'icon'         => [0 => ['class' => 'icon-'], 1 => ['class' => 'icon-user']],
             ],
         ];
         $this->shopLinkType = 'shop';

--- a/controllers/admin/AdminStockConfigurationController.php
+++ b/controllers/admin/AdminStockConfigurationController.php
@@ -68,8 +68,14 @@ class AdminStockConfigurationControllerCore extends AdminController
                     '-1' => $this->l('Decrease'),
                 ],
                 'icon'       => [
-                    -1 => 'remove_stock.png',
-                    1  => 'add_stock.png',
+                    -1 => [
+                        'src' => 'remove_stock.png',
+                        'alt' => $this->l('Decrease'),
+                    ],
+                    1  => [
+                        'src' => 'add_stock.png',
+                        'alt' => $this->l('Increase'),
+                    ],
                 ],
                 'orderby'    => false,
                 'class'      => 'fixed-width-sm',


### PR DESCRIPTION
Note that icons on AdminCartsController and AdminStockConfigurationController are broken. This PR fixes them. I have checked for other controllers, but icons aren't used a lot and the few others seem to do it correctly.

This PR is also a little enhancement. Currently the icons path was kind of hardcoded. The img file needed to be stored in img/admin. This is bad, if you want to use this feature with a module. I changed this behaviour with backwards compatibility. I also allow, to specify an optional width or height value.

In general I love this icon possibility. It's very user friendly in practice. It saves a lot of space and a good icon is easy to "read" for humans. So I recommend, to use it more often :)