### PR TITLE
Replace jquery by vanilla js

### DIFF
--- a/js/trigger.js
+++ b/js/trigger.js
@@ -15,11 +15,11 @@
  * @copyright 2021 - 2021 thirty bees
  * @license   Academic Free License (AFL 3.0)
  */
-$(window).on('load', function() {
+window.addEventListener("load", function() {
   if (window.triggerToken && window.triggerUrl) {
-    $.post(window.triggerUrl, {
-      ajax: 1,
-      secret: window.triggerToken,
-    });
+    var request = new XMLHttpRequest();
+    request.open("POST", window.triggerUrl, true);
+    request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+    request.send("ajax=1&secret="+window.triggerToken);
   }
 });


### PR DESCRIPTION
Like I have written here: https://github.com/thirtybees/thirtybees/issues/1485, we should aim to reduce the jquery lines in core files.
 
This file doesn't seem to make much yet, but it breaks my new theme (when smart cache for js is activated) and no jQuery is loaded. 