### PR TITLE
Administration header hook to notifications area

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -149,6 +149,7 @@
 							</div>
 						</li>
 					{/foreach}
+						{hook h='displayAdminHeaderNotif'}
 				</ul>
 
 {if count($quick_access) >= 0}


### PR DESCRIPTION
Now it´s very hard to add new custom icons for notifications when module need to add some there.
By adding new hook 'displayAdminHeaderNotif' it will be piece of cake, to add even multiple icons there:

![screen-admin-hook-displayAdminHeaderNotif](https://user-images.githubusercontent.com/57491379/193682572-b71daec8-f83b-439d-8600-66c519f82940.png)

(see: red colored icons added as example, but color isn´t matter of commit :)