### PR TITLE
Fix chosen search within word or with spacing

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/features.tpl
+++ b/admin-dev/themes/default/template/controllers/products/features.tpl
@@ -196,7 +196,7 @@
 
     // Make sure, that the chosen select has not a width of 0px
     $(document).ready(function() {
-       $('select.chosen').chosen( { width: '100%' } );
+       $('select.chosen').chosen( { width: '100%', search_contains: true } );
     });
 
 


### PR DESCRIPTION
When initiating the chosen plugin with the search field, it's best to do it with the setting "search_contains: true". 

Otherwise, the search doesn't work:

- within a word
- when the search phrase contains spaces