### PR TITLE
Wrong search indexing of description with words separated by a line break tag

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -343,6 +343,7 @@ class SearchCore
      */
     public static function sanitize($string, $idLang, $indexation = false, $isoCode = false)
     {
+	$string = str_replace(['<br />', '<br/>', '<br>'], ' ', $string);
         $string = trim((string)$string);
         if (empty($string)) {
             return '';


### PR DESCRIPTION
Words separated by line break tag are connected together when sanitizing search string. As a result product is not found when searching.