### PR TITLE
BO: Shorter category description

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -126,7 +126,7 @@ class AdminCategoriesControllerCore extends AdminController
      */
     public static function getDescriptionClean($description)
     {
-        return Tools::getDescriptionClean($description);
+        return substr(Tools::getDescriptionClean($description), 0, 100);
     }
 
     /**


### PR DESCRIPTION
If a category has a very long description, the category list on back office is very unreadable.