### PR TITLE
Removing strange ajax restriction

### DIFF
--- a/controllers/front/AuthController.php
+++ b/controllers/front/AuthController.php
@@ -506,7 +506,7 @@ class AuthControllerCore extends FrontController
         // Check the requires fields which are settings in the BO
         $this->errors = $this->errors + $customer->validateFieldsRequiredDatabase();
 
-        if (!Configuration::get('PS_REGISTRATION_PROCESS_TYPE') && !$this->ajax && !Tools::isSubmit('submitGuestAccount')) {
+        if (!Configuration::get('PS_REGISTRATION_PROCESS_TYPE') && !Tools::isSubmit('submitGuestAccount')) {
             if (!count($this->errors)) {
                 $this->processCustomerNewsletter($customer);
 


### PR DESCRIPTION
While working on my new theme, I came up to the processSubmitAccount() function. 

There is a very strange !$this->ajax restriction. It makes basically no sense as later the code checks for $this->ajax, which would obviously always be false.

I am not totally sure, if this restriction has any sense in some usecases, but I don't think so...