### PR TITLE
Add {followup} and {shipping_number} to all order related mail templates

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -462,11 +462,18 @@ class OrderHistoryCore extends ObjectModel
 			WHERE oh.`id_order_history` = '.(int) $this->id.' AND os.`send_email` = 1');
         if (isset($result['template']) && Validate::isEmail($result['email'])) {
             $topic = $result['osname'];
+            $carrierUrl = '';
+            if (Validate::isLoadedObject($carrier = new Carrier((int) $order->id_carrier, $order->id_lang))) {
+                $carrierUrl = $carrier->url;
+            }
+
             $data = [
                 '{lastname}'   => $result['lastname'],
                 '{firstname}'  => $result['firstname'],
                 '{id_order}'   => (int) $this->id_order,
                 '{order_name}' => $order->getUniqReference(),
+                '{followup}' => str_replace('@', $order->getWsShippingNumber(), $carrierUrl),
+                '{shipping_number}' => $order->getWsShippingNumber(),
             ];
 
             if ($result['module_name']) {


### PR DESCRIPTION
Backport of PrestaShop/PrestaShop#12705 - allows to use `{followup}` in any order related mail template to show the tracking URL. Allows to use `{shipping_number}` to display the bare tracking number.