### PR TITLE
Prevent automatically changing category friendly URL

### DIFF
--- a/controllers/admin/AdminCategoriesController.php
+++ b/controllers/admin/AdminCategoriesController.php
@@ -547,6 +547,7 @@ class AdminCategoriesControllerCore extends AdminController
         }
 
         $thumbSize = file_exists($thumb) ? filesize($thumb) / 1000 : false;
+        $nameClass = (!$obj->id ? 'copy2friendlyUrl' : '');
 
         $this->fields_form = [
             'tinymce' => true,
@@ -561,7 +562,7 @@ class AdminCategoriesControllerCore extends AdminController
                     'name'     => 'name',
                     'lang'     => true,
                     'required' => true,
-                    'class'    => 'copy2friendlyUrl',
+                    'class'    => $nameClass,
                     'hint'     => $this->l('Invalid characters:').' <>;=#{}',
                 ],
                 [


### PR DESCRIPTION
Automatically changing category friendly URL for already indexed pages only causes SEO problems.