### PR TITLE
Adding ajaxDie() in postProcess()

### DIFF
--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -88,6 +88,13 @@ class PasswordControllerCore extends FrontController
                     }
                 }
             }
+            if ($this->ajax) {
+                $return = [
+                    'hasError' => !empty($this->errors),
+                    'errors'   => $this->errors,
+                ];
+                $this->ajaxDie(json_encode($return));
+            }
         } elseif ($customer = $this->getCustomer()) {
             if ((strtotime($customer->last_passwd_gen.'+'.(int) Configuration::get('PS_PASSWD_TIME_FRONT').' minutes') - time()) > 0) {
                 Tools::redirect('index.php?controller=authentication&error_regen_pwd');


### PR DESCRIPTION
Almost all themes don't use ajax calls to submit forms. I will do that differently in my new theme. Many controllers let the process die(), if a submit happened. Unfortunately passwordController is not doing it. 

This is a quick add, to fix this "issue". In the future there will probably come a more advanced PR from me, to clean all controllers. Cause all these things are a little messy. Same is true for redirects, which sometime happen in postProcess, but should actually be used in $this->setRedirect().
