### PR TITLE
Cleanup identity controller

### DIFF
--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -88,7 +88,7 @@ class IdentityControllerCore extends FrontController
                 $this->errors[] = Tools::displayError('An account using this email address has already been registered.');
             } elseif (!Tools::getIsset('old_passwd') || !Customer::checkPassword($this->context->customer->id, Tools::getValue('old_passwd'))) {
                 $this->errors[] = Tools::displayError('The password you entered is incorrect.');
-            } elseif (Tools::getValue('passwd') != Tools::getValue('confirmation')) {
+            } elseif (Tools::getValue('passwd') != Tools::getValue('passwd_confirmation', Tools::getValue('confirmation'))) {
                 $this->errors[] = Tools::displayError('The password and confirmation do not match.');
             } else {
                 $prevIdDefaultGroup = $this->customer->id_default_group;
@@ -132,7 +132,8 @@ class IdentityControllerCore extends FrontController
                 }
             }
         } else {
-            $_POST = array_map('stripslashes', $this->customer->getFields());
+            $customer_fields = array_map('stripslashes', $this->customer->getFields());
+            $_POST = array_merge($_POST, $customer_fields);
         }
 
         return $this->customer;

--- a/controllers/front/IdentityController.php
+++ b/controllers/front/IdentityController.php
@@ -73,8 +73,13 @@ class IdentityControllerCore extends FrontController
 
         if (Tools::isSubmit('submitIdentity')) {
             $email = trim(Tools::getValue('email'));
+            $passwd = Tools::getValue('passwd');
+            $passwd_confirmation = Tools::getValue('passwd_confirmation', Tools::getValue('confirmation')); // 'confirmation' is for backward compatibility
 
-            if (Tools::getValue('months') != '' && Tools::getValue('days') != '' && Tools::getValue('years') != '') {
+            if (Tools::getValue('birthday')) {
+                $this->customer->birthday = Tools::getValue('birthday');
+            }
+            elseif (Tools::getValue('months') != '' && Tools::getValue('days') != '' && Tools::getValue('years') != '') {
                 $this->customer->birthday = (int) Tools::getValue('years').'-'.(int) Tools::getValue('months').'-'.(int) Tools::getValue('days');
             } elseif (Tools::getValue('months') == '' && Tools::getValue('days') == '' && Tools::getValue('years') == '') {
                 $this->customer->birthday = null;
@@ -86,11 +91,16 @@ class IdentityControllerCore extends FrontController
                 $this->errors[] = Tools::displayError('This email address is not valid');
             } elseif ($this->customer->email != $email && Customer::customerExists($email, true)) {
                 $this->errors[] = Tools::displayError('An account using this email address has already been registered.');
-            } elseif (!Tools::getIsset('old_passwd') || !Customer::checkPassword($this->context->customer->id, Tools::getValue('old_passwd'))) {
-                $this->errors[] = Tools::displayError('The password you entered is incorrect.');
-            } elseif (Tools::getValue('passwd') != Tools::getValue('passwd_confirmation', Tools::getValue('confirmation'))) {
-                $this->errors[] = Tools::displayError('The password and confirmation do not match.');
-            } else {
+            } else if ($this->customer->email != $email || $passwd || $passwd_confirmation){
+                // If email or password value does change, the current password is required
+                if (!Tools::getIsset('old_passwd') || !Customer::checkPassword($this->context->customer->id, Tools::getValue('old_passwd'))) {
+                    $this->errors[] = Tools::displayError('The password you entered is incorrect.');
+                } elseif ($passwd != $passwd_confirmation) {
+                    $this->errors[] = Tools::displayError('The password and confirmation do not match.');
+                }
+            }
+
+            if (empty($this->errors)) {
                 $prevIdDefaultGroup = $this->customer->id_default_group;
 
                 // Merge all errors of this file and of the Object Model
@@ -126,6 +136,7 @@ class IdentityControllerCore extends FrontController
                 if ($this->customer->update()) {
                     $this->context->cookie->customer_lastname = $this->customer->lastname;
                     $this->context->cookie->customer_firstname = $this->customer->firstname;
+                    $this->context->cookie->email = $this->customer->email;
                     $this->context->smarty->assign('confirmation', 1);
                 } else {
                     $this->errors[] = Tools::displayError('The information cannot be updated.');


### PR DESCRIPTION
As dicussed in this thread (https://forum.thirtybees.com/topic/5945-improvements-on-identitycontroller-needed-or-not/) I have improved the identity form a little bit.

Now only sensible data need the password change. This was already implemented in niara:
[identity.webm](https://user-images.githubusercontent.com/15154932/206494625-6165231f-c529-411f-9850-f049e5a50330.webm)

Now you can also use field "birthday" with type 'date' if you want. It wasn't implemented in niara yet, as there was no clear wanting in the community. But the option for a theme designer is still nice.

Technically this should be fully backward compatible:

- Now it's recommended to use input name "passwd_confirmation" instead of just "confirmation". 
- Now existing $_POST values aren't just dropped, but merged.