### PR TITLE
Allow list filtering by url: https://github.com/thirtybees/thirtybees/issues/1601

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -318,7 +318,7 @@
 								--
 							{else}
 								{if $params.type == 'bool'}
-									<select class="filter fixed-width-sm center" name="{$list_id}Filter_{if isset($params.filter_key)}{$params.filter_key}{else}{$key}{/if}">
+									<select class="filter fixed-width-xs center" name="{$list_id}Filter_{if isset($params.filter_key)}{$params.filter_key}{else}{$key}{/if}">
 										<option value="">-</option>
 										<option value="1" {if $params.value == 1} selected="selected" {/if}>{l s='Yes'}</option>
 										<option value="0" {if $params.value == 0 && $params.value != ''} selected="selected" {/if}>{l s='No'}</option>

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -314,12 +314,19 @@ class LinkCore
      *
      * @throws PrestaShopException
      */
-    public function getAdminLink($controller, $withToken = true, $params = [])
+    public function getAdminLink($controller, $withToken = true, $params = [], $filters = [])
     {
         $idLang = Context::getContext()->language->id;
 
         if ($withToken) {
             $params['token'] = Tools::getAdminTokenLite($controller);
+        }
+
+        if (!empty($filters)) {
+            $params['submitFilterForced'] = true;
+            foreach ($filters as $column => $value) {
+                $params['list_idFilter_' . $column] = pSQL($value);
+            }
         }
 
         return Dispatcher::getInstance()->createUrl($controller, $idLang, $params, false);

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -626,6 +626,11 @@ class AdminControllerCore extends Controller
 
         $prefix = $this->getCookieFilterPrefix();
 
+        // Reset current filter, if forced filter was applied
+        if (Tools::isSubmit('submitFilterForced')) {
+            $this->processResetFilters();
+        }
+
         if (isset($this->list_id)) {
             foreach ($_POST as $key => $value) {
                 if ($value === '') {
@@ -638,6 +643,12 @@ class AdminControllerCore extends Controller
             }
 
             foreach ($_GET as $key => $value) {
+
+                // Handle forced filtering parameter by url
+                if (stripos($key, 'list_idFilter_') === 0) {
+                    $key = str_replace('list_id', $this->list_id, $key);
+                }
+
                 if (stripos($key, $this->list_id.'Filter_') === 0) {
                     $this->context->cookie->{$prefix.$key} = !is_array($value) ? $value : json_encode($value);
                 } elseif (stripos($key, 'submitFilter') === 0) {
@@ -3927,6 +3938,7 @@ class AdminControllerCore extends Controller
             || $this->context->cookie->{'submitFilter'.$this->list_id} !== false
             || Tools::getValue($this->list_id.'Orderby')
             || Tools::getValue($this->list_id.'Orderway')
+            || Tools::isSubmit('submitFilterForced')
         ) {
             $this->filter = true;
         }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -629,6 +629,7 @@ class AdminControllerCore extends Controller
         // Reset current filter, if forced filter was applied
         if (Tools::isSubmit('submitFilterForced')) {
             $this->processResetFilters();
+            $_POST['submitFilter'.$this->list_id] = true;
         }
 
         if (isset($this->list_id)) {
@@ -646,7 +647,7 @@ class AdminControllerCore extends Controller
 
                 // Handle forced filtering parameter by url
                 if (stripos($key, 'list_idFilter_') === 0) {
-                    $key = str_replace('list_id', $this->list_id, $key);
+                    $key = preg_replace('/list_id/', $this->list_id, $key, 1);
                 }
 
                 if (stripos($key, $this->list_id.'Filter_') === 0) {

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -339,6 +339,7 @@ class AdminProductsControllerCore extends AdminController
                 'filter_key'   => 'sav!quantity',
                 'orderby'      => true,
                 'badge_danger' => true,
+                'callback' => 'callbackRenderStockLink'
                 //'hint' => $this->l('This is the quantity available in the current shop/group.'),
             ];
         }
@@ -6551,6 +6552,21 @@ class AdminProductsControllerCore extends AdminController
 
         // use shop group settings
         return $shareStock;
+    }
+
+    /**
+     * @param int $quantity
+     * @param array $row
+     *
+     * @return string
+     */
+    public function callbackRenderStockLink($quantity, $row) {
+        if (!empty($row['reference'])) {
+            $stockLink = $this->context->link->getAdminLink('AdminStockInstantState', true, [], ['reference' => $row['reference']]);
+            $style = $quantity<=0 ? 'color: #FFF' : 'color: #666';
+            return "<a style='{$style}' href={$stockLink}>{$quantity}</a>";
+        }
+        return $quantity;
     }
 
 }


### PR DESCRIPTION
This PR is a proposal, how we could handle https://github.com/thirtybees/thirtybees/issues/1601. It allows you to simply use getAdminLink() function and set up filters for a list. 

Note: im my branch there are two commits. The first one implements the new feature. The second is applying it to AdminProducts List by linking the quantity to AdminStockInstantState. 

For the second commit my code is a bit ugly:
`$style = $quantity<=0 ? 'color: #FFF' : 'color: #666';`

This would be better done by css. But I don't know which files I need to change. Obviously the second commit can also be skipped completly, if it's not wished.