### PR TITLE
Improving customer search for multiple words search

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -1309,14 +1309,24 @@ class AdminCustomersControllerCore extends AdminController
         $customers = [];
         $searches = array_unique($searches);
         foreach ($searches as $search) {
-            if (!empty($search) && $results = Customer::searchByName($search, 50)) {
+            if (!empty($search) && $results = Customer::searchByName($search)) {
                 foreach ($results as $result) {
                     if ($result['active']) {
-                        $customers[$result['id_customer']] = $result;
+                        if (!isset($customers[$result['id_customer']])) {
+                            $customers[$result['id_customer']] = $result;
+                            $customers[$result['id_customer']]['sort_score'] = 1;
+                        }
+                        else {
+                            $customers[$result['id_customer']]['sort_score'] += 1;
+                        }
                     }
                 }
             }
         }
+
+        array_multisort(array_column($customers, 'sort_score'), SORT_DESC, $customers);
+
+        $customers = array_slice($customers, 0, 100);
 
         if (! headers_sent()) {
             header('Content-Type: application/json');


### PR DESCRIPTION
When you have a lot of customer entries, the customer search in BO is quite useless/messy. 

Imagine you search for "John Doe". You will get the first 50 Johns and the first 50 Does. In practice that could even mean that you don't get the combination "John Doe". More often you get the "John Doe" but it's somewhere between the other result (hard to find). 

This PR fixes this. It adds a little sort_score and limit the total results to 100 only at the end. So it will show "John Doe" as the first result and only then "John McEnroe" or "Sabrina Doe". 