### PR TITLE
Update Product Class for Ecotax calculation right

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1165,29 +1165,6 @@ class ProductCore extends ObjectModel
             $price = $productTaxCalculator->addTaxes($price);
         }
 
-        // Eco Tax
-        if (($result['ecotax'] || isset($result['attribute_ecotax'])) && $withEcotax) {
-            $ecotax = $result['ecotax'];
-            if (isset($result['attribute_ecotax']) && $result['attribute_ecotax'] > 0) {
-                $ecotax = $result['attribute_ecotax'];
-            }
-
-            if ($idCurrency) {
-                $ecotax = Tools::convertPrice($ecotax, $idCurrency);
-            }
-            if ($useTax) {
-                // reinit the tax manager for ecotax handling
-                $taxManager = TaxManagerFactory::getManager(
-                    $address,
-                    (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID')
-                );
-                $ecotaxTaxCalculator = $taxManager->getTaxCalculator();
-                $price += $ecotaxTaxCalculator->addTaxes($ecotax);
-            } else {
-                $price += $ecotax;
-            }
-        }
-
         // Reduction
         $specificPriceReduction = 0;
         if (($onlyReduc || $useReduc) && $specificPrice) {
@@ -1258,6 +1235,29 @@ class ProductCore extends ObjectModel
                 );
             } else {
                 return Tools::ps_round($specificPriceReduction, $decimals);
+            }
+        }
+		
+		// Eco Tax
+        if (($result['ecotax'] || isset($result['attribute_ecotax'])) && $withEcotax) {
+            $ecotax = $result['ecotax'];
+            if (isset($result['attribute_ecotax']) && $result['attribute_ecotax'] > 0) {
+                $ecotax = $result['attribute_ecotax'];
+            }
+
+            if ($idCurrency) {
+                $ecotax = Tools::convertPrice($ecotax, $idCurrency);
+            }
+            if ($useTax) {
+                // reinit the tax manager for ecotax handling
+                $taxManager = TaxManagerFactory::getManager(
+                    $address,
+                    (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID')
+                );
+                $ecotaxTaxCalculator = $taxManager->getTaxCalculator();
+                $price += $ecotaxTaxCalculator->addTaxes($ecotax);
+            } else {
+                $price += $ecotax;
             }
         }
 


### PR DESCRIPTION
It is necessary to not apply discount on the product price that include ecotax, it needs to be calculated without this tax and add it again afterward.

Like this PR suggest it for PS 1.6, it is tested and it works fine. https://github.com/PrestaShop/PrestaShop/pull/22694/commits/6b1f81eae21f8eeeb82f0f6998a7124fa20e3bf9