### PR TITLE
Improving accounting stats

### DIFF
--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -596,6 +596,8 @@ abstract class PaymentModuleCore extends Module
                         $orderCarrier->weight = (float) $order->getTotalWeight();
                         $orderCarrier->shipping_cost_tax_excl = (float) $order->total_shipping_tax_excl;
                         $orderCarrier->shipping_cost_tax_incl = (float) $order->total_shipping_tax_incl;
+                        $id_country = $address->id_country ?? (new Address($idAddress))->id_country;
+                        $orderCarrier->setShippingCostAccounting($carrier, $orderCarrier->shipping_cost_tax_excl, $id_country, $order->conversion_rate);
                         $orderCarrier->add();
                     }
                 }

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1594,7 +1594,7 @@ class OrderCore extends ObjectModel
                 $orderPayment->amount = $this->total_paid_tax_incl;
                 $orderPayment->payment_method = $this->payment;
                 $orderPayment->conversion_rate = $this->conversion_rate;
-                $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency);
+                $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency, $orderPayment->conversion_rate);
                 $orderPayment->add();
 
                 Db::getInstance()->insert(
@@ -2163,7 +2163,7 @@ class OrderCore extends ObjectModel
         $orderPayment->transaction_id = $paymentTransactionId;
         $orderPayment->amount = $amountPaid;
         $orderPayment->date_add = ($date ? $date : null);
-        $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency);
+        $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency, $orderPayment->conversion_rate);
 
         // Add time to the date if needed
         if ($orderPayment->date_add != null && preg_match('/^[0-9]+-[0-9]+-[0-9]+$/', $orderPayment->date_add)) {

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1594,7 +1594,7 @@ class OrderCore extends ObjectModel
                 $orderPayment->amount = $this->total_paid_tax_incl;
                 $orderPayment->payment_method = $this->payment;
                 $orderPayment->conversion_rate = $this->conversion_rate;
-
+                $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency);
                 $orderPayment->add();
 
                 Db::getInstance()->insert(
@@ -2163,6 +2163,7 @@ class OrderCore extends ObjectModel
         $orderPayment->transaction_id = $paymentTransactionId;
         $orderPayment->amount = $amountPaid;
         $orderPayment->date_add = ($date ? $date : null);
+        $orderPayment->setPaymentCostAccounting($this->module, $orderPayment->amount, $orderPayment->id_currency);
 
         // Add time to the date if needed
         if ($orderPayment->date_add != null && preg_match('/^[0-9]+-[0-9]+-[0-9]+$/', $orderPayment->date_add)) {

--- a/classes/order/OrderCarrier.php
+++ b/classes/order/OrderCarrier.php
@@ -112,7 +112,7 @@ class OrderCarrierCore extends ObjectModel
      */
     public function setShippingCostAccounting($carrier, $shipping_cost, $id_country, $conversionRate) {
 
-        if (is_int($carrier)) {
+        if (!is_object($carrier) && Validate::isUnsignedId($carrier)) {
             $carrier = new Carrier($carrier);
         }
 

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -349,6 +349,7 @@ class OrderHistoryCore extends ObjectModel
                     $order->save();
 
                     $payment->conversion_rate = 1;
+                    $payment->setPaymentCostAccounting($order->module, $payment->amount, $payment->id_currency);
                     $payment->save();
                     Db::getInstance()->insert(
                         'order_invoice_payment',

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -349,7 +349,7 @@ class OrderHistoryCore extends ObjectModel
                     $order->save();
 
                     $payment->conversion_rate = 1;
-                    $payment->setPaymentCostAccounting($order->module, $payment->amount, $payment->id_currency);
+                    $payment->setPaymentCostAccounting($order->module, $payment->amount, $payment->id_currency, $payment->conversion_rate);
                     $payment->save();
                     Db::getInstance()->insert(
                         'order_invoice_payment',

--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -216,9 +216,10 @@ class OrderPaymentCore extends ObjectModel
      * @param string $payment_module PaymentModuleName
      * @param float $transaction_amount Transaction Amount
      * @param int $id_currency ID Currency
+     * @param float $conversionRate Order Conversion Rate
      *
      */
-    public function setPaymentCostAccounting($payment_module, $transaction_amount, $id_currency) {
+    public function setPaymentCostAccounting($payment_module, $transaction_amount, $id_currency, $conversionRate) {
 
         $payment_module_config = strtoupper((string)$payment_module);
 
@@ -231,6 +232,6 @@ class OrderPaymentCore extends ObjectModel
             $fee_absolute = Configuration::get('CONF_'.$payment_module_config.'_FIXED_FOREIGN');
         }
 
-        $this->payment_cost_accounting = Tools::ps_round($fee_absolute + ($fee_relative/100*$transaction_amount), 6);
+        $this->payment_cost_accounting = Tools::ps_round($fee_absolute*$conversionRate + ($fee_relative/100*$transaction_amount), 6);
     }
 }

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -127,7 +127,7 @@ class AdminDashboardControllerCore extends AdminController
             $forms['carriers']['fields']['CONF_'.strtoupper($carrier['id_reference']).'_SHIP_FIXED'] = [
                 'title'        => $carrier['name'],
                 'desc'         => sprintf($this->l('Fixed Fee for the carrier on domestic delivery.'), $carrier['name']),
-                'validation'   => 'isPercentage',
+                'validation'   => 'isPrice',
                 'cast'         => 'floatval',
                 'type'         => 'text',
                 'defaultValue' => '0',

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -124,6 +124,15 @@ class AdminDashboardControllerCore extends AdminController
         }
 
         foreach ($carriers as $carrier) {
+            $forms['carriers']['fields']['CONF_'.strtoupper($carrier['id_reference']).'_SHIP_FIXED'] = [
+                'title'        => $carrier['name'],
+                'desc'         => sprintf($this->l('Fixed Fee for the carrier on domestic delivery.'), $carrier['name']),
+                'validation'   => 'isPercentage',
+                'cast'         => 'floatval',
+                'type'         => 'text',
+                'defaultValue' => '0',
+                'suffix'       => $currency->iso_code,
+            ];
             $forms['carriers']['fields']['CONF_'.strtoupper($carrier['id_reference']).'_SHIP'] = [
                 'title'        => $carrier['name'],
                 'desc'         => sprintf($this->l('For the carrier named %s, indicate the domestic delivery costs  in percentage of the price charged to customers.'), $carrier['name']),
@@ -132,6 +141,15 @@ class AdminDashboardControllerCore extends AdminController
                 'type'         => 'text',
                 'defaultValue' => '0',
                 'suffix'       => '%',
+            ];
+            $forms['carriers']['fields']['CONF_'.strtoupper($carrier['id_reference']).'_SHIP_FIXED_OVERSEAS'] = [
+                'title'        => $carrier['name'],
+                'desc'         => sprintf($this->l('Fixed Fee for the carrier on oversea delivery.'), $carrier['name']),
+                'validation'   => 'isPrice',
+                'cast'         => 'floatval',
+                'type'         => 'text',
+                'defaultValue' => '0',
+                'suffix'       => $currency->iso_code,
             ];
             $forms['carriers']['fields']['CONF_'.strtoupper($carrier['id_reference']).'_SHIP_OVERSEAS'] = [
                 'title'        => $carrier['name'],


### PR DESCRIPTION
As already a bit discuessed here: https://forum.thirtybees.com/topic/5983-all-purchase_supplier_price-in-order_detail-table-wrong/ tb doesn't save all pricing information historically. 

This PR does solve this issue (at least in some ways). It adds two columns to the DB:

- shipping_cost_accounting
- payment_cost_accounting

This means, that order profits don't change, if you change your cost configs in the future. In addition this PR allows to set up absolute fees for carriers. For payment this was already there. Dashboard profit values will be calculated with the new method, but is backward compatible.

**Be careful:** I have this active for 2 weeks and it seems to work perfectly. But merchants need to update their Database by core updater module. If they forget it, they will see exceptions at very critical stages (order validation for example).

Note:

- If this gets merged, the orderprofitstats should be updated as well.
- I haven't implemented any BO edit of these new columns/values. It was also not possible before. IMO it's not important at the moment, but could be extended in the future. 