### PR TITLE
Message to order

### DIFF
--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -936,7 +936,7 @@ abstract class PaymentModuleCore extends Module
                     $customerMessage->id_customer_thread = $customerThread->id;
                     $customerMessage->id_employee = 0;
                     $customerMessage->message = $updateMessage->message;
-                    $customerMessage->private = 1;
+                    $customerMessage->private = 0;
                     $customerMessage->add();
                 }
 


### PR DESCRIPTION
Saving a message to an order with a status of "private" is rather a mistake.
Customers don't see this message in the order history and think it didn't get added. They write it again, or call the store.
