### PR TITLE
Product reference code - whitespace at the beginning and end

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -534,7 +534,7 @@ class ValidateCore
      */
     public static function isReference($reference)
     {
-        return (bool) preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;={}]*$/u'), $reference);
+        return (bool) preg_match(Tools::cleanNonUnicodeSupport('/^[^\s<>;={}]*$/u'), $reference);
     }
 
     /**


### PR DESCRIPTION
Issue:
In Administration > Catalog > Products > (any product) > [Edit]
in field "Reference code" must not be allowed to use space before first or after last character in code:
"abc123" is not same as " abc123" or "abc123 ".
This is not problem for eshop employees, but big issue for sync eshop products with third party applications where reference code is used as only key to recognize pairs.

Fix:
In ".\classes\Validate.php" make function "isReference" more precise with correct regex to avoid spaces at all.