### PR TITLE
Pagination: wrong canonical URL

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -445,6 +445,10 @@ class FrontControllerCore extends Controller
                 break;
 
         }
+        // append page number
+        if ($p = Tools::getIntValue('p')) {
+            $canonical .= "?p=$p";
+        }
         // build new content
         $content .= '<link rel="canonical" href="'.$canonical.'">'."\n";
         if (is_array($hreflang) && !empty($hreflang)) {


### PR DESCRIPTION
Quote: "Don't use the first page of a paginated sequence as the canonical page."
https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading
