### PR TITLE
Check for {extends} in FO translations

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1870,6 +1870,11 @@ class AdminTranslationsControllerCore extends AdminController
                     // Get content for this file
                     $content = file_get_contents($filePath);
 
+                    // Check if the tpl file uses extends functionality
+                    if (preg_match('/{extends\s+file="([^"]+)"/', $content, $extendMatches)) {
+                        $prefixKey = $prefix.substr(basename($extendMatches[1]), 0, -4);
+                    }
+
                     // Parse this content
                     $matches = $this->userParseFile($content, $this->type_selected);
 


### PR DESCRIPTION
This PR should fix: https://github.com/thirtybees/thirtybees/issues/1717

I am very busy right now, so I haven't tested this very deeply. But for me it works nicely.