### PR TITLE
Move updateShippingNumber to OrderCarrier class so it can be used by other scripts.

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -601,65 +601,37 @@ class AdminOrdersControllerCore extends AdminController
                 } elseif (!Validate::isTrackingNumber($trackingNumber)) {
                     $this->errors[] = Tools::displayError('The tracking number is incorrect.');
                 } else {
-                    // update shipping number
-                    // Keep these two following lines for backward compatibility, remove on 1.6 version
-                    $order->shipping_number = $trackingNumber;
-                    $order->update();
-
-                    // Update order_carrier
-                    $orderCarrier->tracking_number = pSQL($trackingNumber);
-                    if ($orderCarrier->update()) {
-                        // Send mail to customer
-                        $customer = new Customer((int) $order->id_customer);
-                        $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
-                        if (!Validate::isLoadedObject($customer)) {
-                            throw new PrestaShopException('Can\'t load Customer object');
-                        }
-                        if (!Validate::isLoadedObject($carrier)) {
-                            throw new PrestaShopException('Can\'t load Carrier object');
-                        }
-                        $templateVars = [
-                            '{followup}'         => str_replace('@', $trackingNumber, $carrier->url),
-                            '{firstname}'        => $customer->firstname,
-                            '{lastname}'         => $customer->lastname,
-                            '{id_order}'         => $order->id,
-                            '{shipping_number}'  => $trackingNumber,
-                            '{order_name}'       => $order->getUniqReference(),
-                            '{bankwire_owner}'   => (string) Configuration::get('BANK_WIRE_OWNER'),
-                            '{bankwire_details}' => (string) nl2br(Configuration::get('BANK_WIRE_DETAILS')),
-                            '{bankwire_address}' => (string) nl2br(Configuration::get('BANK_WIRE_ADDRESS')),
-                        ];
-                        if (@Mail::Send(
-                            (int) $order->id_lang,
-                            'in_transit',
-                            Mail::l('Package in transit', (int) $order->id_lang),
-                            $templateVars,
-                            $customer->email,
-                            $customer->firstname.' '.$customer->lastname,
-                            null,
-                            null,
-                            null,
-                            null,
-                            _PS_MAIL_DIR_,
-                            true,
-                            (int) $order->id_shop
-                        )) {
-                            Hook::triggerEvent(
-                                'actionAdminOrdersTrackingNumberUpdate',
-                                [
-                                    'order' => $order,
-                                    'customer' => $customer,
-                                    'carrier' => $carrier
-                                ],
-                                $order->id_shop
-                            );
-                            Tools::redirectAdmin(static::$currentIndex.'&id_order='.$order->id.'&vieworder&conf=4&token='.$this->token);
-                        } else {
-                            $this->errors[] = Tools::displayError('An error occurred while sending an email to the customer.');
-                        }
-                    } else {
-                        $this->errors[] = Tools::displayError('The order carrier cannot be updated.');
+                    // Backward compatibility for actionAdminOrdersTrackingNumberUpdate
+                    $customer = new Customer((int) $order->id_customer);
+                    $carrier = new Carrier((int) $order->id_carrier, $order->id_lang);
+                    if (!Validate::isLoadedObject($customer)) {
+                        throw new PrestaShopException('Can\'t load Customer object');
                     }
+                    if (!Validate::isLoadedObject($carrier)) {
+                        throw new PrestaShopException('Can\'t load Carrier object');
+                    }
+                    // END:Backward compatibility for actionAdminOrdersTrackingNumberUpdate
+                    if(
+                        $orderCarrier->updateTrackingNumber(
+                            $trackingNumber,
+                            true,
+                            $this->errors
+                        )
+                    ){
+                        // Backward compatibility for actionAdminOrdersTrackingNumberUpdate
+                        Hook::triggerEvent(
+                            'actionAdminOrdersTrackingNumberUpdate',
+                            [
+                                'order' => $order,
+                                'customer' => $customer,
+                                'carrier' => $carrier
+                            ],
+                            $order->id_shop
+                        );
+                        // END:Backward compatibility for actionAdminOrdersTrackingNumberUpdate
+                        Tools::redirectAdmin(static::$currentIndex.'&id_order='.$order->id.'&vieworder&conf=4&token='.$this->token);
+                    }
+
                 }
             } else {
                 $this->errors[] = Tools::displayError('You do not have permission to edit this.');


### PR DESCRIPTION
Up until now, any external (via module) update of shipping number would require a module to send in_transit email on its own (and manage variables etc. for each tb version)

Acually had hard time deciding if should use &$errors isntaed of exceptions.
This case has lightErrors (mail not sent) and Heavey errors (invalid number)
Should lightError acually fail triggerEvent? I think not - as reference was updated. So update was a sccess and I don't think it should not triggerEvent, even if email was not sent.

Fixes #1750
Acually may affect #297 and adds shipping_number from #856