### PR TITLE
Small improvement of shortcodes in order messages

### DIFF
--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -97,7 +97,7 @@ class OrderMessageCore extends ObjectModel
             }
 
             if (Validate::isLoadedObject($order) && Validate::isLoadedObject($customer)) {
-                self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);
+                $orderMessages = self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);
             }
 
         }
@@ -110,10 +110,13 @@ class OrderMessageCore extends ObjectModel
      * @param int $idLang
      * @param \Order $order
      * @param \Customer $customer
+     * @param bool $returnShortcodeList
+     *
+     * @return array
      *
      * @throws PrestaShopException
      */
-    private static function replaceShortcodesInOrderMessages(&$orderMessages, $idLang, $order, $customer) {
+    private static function replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer, $returnShortcodeList = false) {
 
         $gender = new Gender($customer->id_gender, $idLang, $order->id_shop);
         $addressDelivery = new Address($order->id_address_delivery, $idLang);
@@ -132,8 +135,23 @@ class OrderMessageCore extends ObjectModel
             '[order_address_invoice]' => AddressFormat::generateAddress($addressInvoice),
         ];
 
+        if ($returnShortcodeList) {
+            return array_keys($shortcodesList);
+        }
+
         foreach ($orderMessages as &$orderMessage) {
             $orderMessage['message'] = str_replace(array_keys($shortcodesList), array_values($shortcodesList), $orderMessage['message']);
         }
+
+        return $orderMessages;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    public static function getShortcodeList() {
+        return self::replaceShortcodesInOrderMessages([], Configuration::get('PS_LANG_DEFAULT'), new Order(), new Customer(), true);
     }
 }

--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -70,7 +70,7 @@ class OrderMessageCore extends ObjectModel
     /**
      * @param int $idLang
      * @param \Order|int $order
-     * @param \Customer $customer
+     * @param \Customer|int $customer
      *
      * @return array
      *
@@ -91,8 +91,9 @@ class OrderMessageCore extends ObjectModel
             $order = new Order($order);
         }
 
-        if (!Validate::isLoadedObject($customer)) {
-            $customer = new Customer($order->id_customer);
+        if (!Validate::isLoadedObject($customer) && (Validate::isUnsignedInt($customer) || Validate::isLoadedObject($order))) {
+            $id_customer = Validate::isUnsignedInt($customer) ? $customer : $order->id_customer;
+            $customer = new Customer($id_customer);
         }
 
         return self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);

--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -69,19 +69,71 @@ class OrderMessageCore extends ObjectModel
 
     /**
      * @param int $idLang
+     * @param \Order|int $order
+     * @param \Customer $customer
      *
      * @return array
      *
      * @throws PrestaShopDatabaseException
      * @throws PrestaShopException
      */
-    public static function getOrderMessages($idLang)
+    public static function getOrderMessages($idLang, $order = null, $customer = null)
     {
-        return Db::readOnly()->getArray('
+        $orderMessages = Db::readOnly()->getArray('
 		SELECT om.id_order_message, oml.name, oml.message
 		FROM '._DB_PREFIX_.'order_message om
 		LEFT JOIN '._DB_PREFIX_.'order_message_lang oml ON (oml.id_order_message = om.id_order_message)
 		WHERE oml.id_lang = '.(int) $idLang.'
 		ORDER BY name ASC');
+
+        // Replace Shortcodes
+        if ($order) {
+            if (!Validate::isLoadedObject($order) && Validate::isUnsignedInt($order)) {
+                $order = new Order($order);
+            }
+
+            if (!Validate::isLoadedObject($customer)) {
+                $customer = new Customer($order->id_customer);
+            }
+
+            if (Validate::isLoadedObject($order) && Validate::isLoadedObject($customer)) {
+                self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);
+            }
+
+        }
+
+        return $orderMessages;
+    }
+
+    /**
+     * @param array $orderMessages
+     * @param int $idLang
+     * @param \Order $order
+     * @param \Customer $customer
+     *
+     * @throws PrestaShopException
+     */
+    private static function replaceShortcodesInOrderMessages(&$orderMessages, $idLang, $order, $customer) {
+
+        $gender = new Gender($customer->id_gender, $idLang, $order->id_shop);
+        $addressDelivery = new Address($order->id_address_delivery, $idLang);
+        $addressInvoice = new Address($order->id_address_invoice, $idLang);
+
+        $shortcodesList = [
+            '[customer_firstname]' => $customer->firstname,
+            '[customer_lastname]' => $customer->lastname,
+            '[customer_gender]' => $gender->name,
+            '[order_reference]' => $order->reference,
+            '[order_date]' => Tools::displayDate($order->date_add),
+            '[order_delivery_date]' => Tools::displayDate($order->delivery_date),
+            '[order_total_paid_tax_incl]' => Tools::displayPrice($order->total_paid_tax_incl, $order->id_currency),
+            '[order_total_paid_tax_excl]' => Tools::displayPrice($order->total_paid_tax_excl, $order->id_currency),
+            '[order_address_delivery]' => AddressFormat::generateAddress($addressDelivery),
+            '[order_address_invoice]' => AddressFormat::generateAddress($addressInvoice),
+        ];
+
+        foreach ($orderMessages as &$orderMessage) {
+            $orderMessage['message'] = str_replace(array_keys($shortcodesList), array_values($shortcodesList), $orderMessage['message']);
+        }
     }
 }

--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -87,22 +87,15 @@ class OrderMessageCore extends ObjectModel
 		ORDER BY name ASC');
 
         // Replace Shortcodes
-        if ($order) {
-            if (!Validate::isLoadedObject($order) && Validate::isUnsignedInt($order)) {
-                $order = new Order($order);
-            }
-
-            if (!Validate::isLoadedObject($customer)) {
-                $customer = new Customer($order->id_customer);
-            }
-
-            if (Validate::isLoadedObject($order) && Validate::isLoadedObject($customer)) {
-                $orderMessages = self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);
-            }
-
+        if (!Validate::isLoadedObject($order) && Validate::isUnsignedInt($order)) {
+            $order = new Order($order);
         }
 
-        return $orderMessages;
+        if (!Validate::isLoadedObject($customer)) {
+            $customer = new Customer($order->id_customer);
+        }
+
+        return self::replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer);
     }
 
     /**
@@ -117,6 +110,14 @@ class OrderMessageCore extends ObjectModel
      * @throws PrestaShopException
      */
     private static function replaceShortcodesInOrderMessages($orderMessages, $idLang, $order, $customer, $returnShortcodeList = false) {
+
+        if (!Validate::isLoadedObject($order)) {
+            $order = new Order();
+        }
+
+        if (!Validate::isLoadedObject($customer)) {
+            $customer = new Customer();
+        }
 
         $gender = new Gender($customer->id_gender, $idLang, $order->id_shop);
         $addressDelivery = new Address($order->id_address_delivery, $idLang);

--- a/classes/order/OrderMessage.php
+++ b/classes/order/OrderMessage.php
@@ -122,6 +122,8 @@ class OrderMessageCore extends ObjectModel
         $addressDelivery = new Address($order->id_address_delivery, $idLang);
         $addressInvoice = new Address($order->id_address_invoice, $idLang);
 
+        $context = Context::getContext();
+
         $shortcodesList = [
             '[customer_firstname]' => $customer->firstname,
             '[customer_lastname]' => $customer->lastname,
@@ -133,6 +135,8 @@ class OrderMessageCore extends ObjectModel
             '[order_total_paid_tax_excl]' => Tools::displayPrice($order->total_paid_tax_excl, $order->id_currency),
             '[order_address_delivery]' => AddressFormat::generateAddress($addressDelivery),
             '[order_address_invoice]' => AddressFormat::generateAddress($addressInvoice),
+            '[employee_firstname]' => $context->employee->firstname,
+            '[employee_lastname]' => $context->employee->lastname,
         ];
 
         if ($returnShortcodeList) {

--- a/controllers/admin/AdminOrderMessageController.php
+++ b/controllers/admin/AdminOrderMessageController.php
@@ -99,6 +99,7 @@ class AdminOrderMessageControllerCore extends AdminController
                     'label'    => $this->l('Message'),
                     'name'     => 'message',
                     'required' => true,
+                    'desc'     => $this->l('Available Shortcodes').': '.implode(', ', OrderMessage::getShortcodeList())
                 ],
             ],
             'submit' => [

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1978,7 +1978,7 @@ class AdminOrdersControllerCore extends AdminController
             'total_paid'                   => $order->getTotalPaid(),
             'returns'                      => OrderReturn::getOrdersReturn($order->id_customer, $order->id),
             'customer_thread_message'      => CustomerThread::getCustomerMessages($order->id_customer, null, $order->id),
-            'orderMessages'                => OrderMessage::getOrderMessages($order->id_lang),
+            'orderMessages'                => OrderMessage::getOrderMessages($order->id_lang, $order, $customer),
             'orderDocuments'               => $order->getDocuments(),
             'messages'                     => CustomerMessage::getMessagesByOrderId($order->id, false),
             'carrier'                      => new Carrier($order->id_carrier),


### PR DESCRIPTION
I assume that https://github.com/thirtybees/thirtybees/pull/1774 will be merged somehow. To make this really "useful". We also need to remove the order restriction. So that an order message can replace customer shortcodes, even if there is no order linked to the message.