### PR TITLE
Add missing store_contacts.csv and fix an issue with hours field

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -523,7 +523,7 @@ class AdminImportControllerCore extends AdminController
                     'fax'       => ['label' => $this->l('Fax')],
                     'email'     => ['label' => $this->l('Email address')],
                     'note'      => ['label' => $this->l('Note')],
-                    'hours'     => ['label' => $this->l('Hours (x,y,z...)')],
+                    'hours'     => ['label' => $this->l('Hours (x;y;z...)')],
                     'image'     => ['label' => $this->l('Image URL')],
                     'shop'      => [
                         'label' => $this->l('ID / Name of shop'),
@@ -4640,8 +4640,13 @@ class AdminImportControllerCore extends AdminController
             }
         }
 
-        if (isset($store->hours) && is_array($store->hours)) {
-            $store->hours = serialize($store->hours);
+        // Handle hours field
+        if (isset($info['hours']) && is_string($info['hours'])) {
+            // Convert the CSV string to an array using ; as the delimiter
+            $hoursArray = explode(';', $info['hours']);
+            $store->hours = json_encode($hoursArray);
+        } elseif (isset($store->hours) && is_array($store->hours)) {
+            $store->hours = json_encode($store->hours);
         }
 
         if (isset($store->country) && is_numeric($store->country)) {

--- a/docs/csv_import/store_contacts.csv
+++ b/docs/csv_import/store_contacts.csv
@@ -1,0 +1,6 @@
+Store ID,active,name,address1,address2,postcode,state,city,country,latitude,longitude,phone,fax,email,note,hours,image
+1,1,Dade County,3030 SW 8th St Miami,,33135,Florida,Miami,United States,25.76500500,-80.24379700,,,,,09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;10:00 - 16:00;10:00 - 16:00,http://yourlinktotheimage.com/img1.jpg
+2,1,E Fort Lauderdale,1000 Northeast 4th Ave Fort Lauderdale,,33304,Florida,Miami,United States,26.13793600,-80.13943500,,,,,09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;10:00 - 16:00;10:00 - 16:00,http://yourlinktotheimage.com/img2.jpg
+3,1,Pembroke Pines,11001 Pines Blvd Pembroke Pines,,33026,Florida,Miami,United States,26.00998700,-80.29447200,,,,,09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;10:00 - 16:00;10:00 - 16:00,http://yourlinktotheimage.com/img3.jpg
+4,1,Coconut Grove,2999 SW 32nd Avenue,,33133,Florida,Miami,United States,25.73629600,-80.24479700,,,,,09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;10:00 - 16:00;10:00 - 16:00,http://yourlinktotheimage.com/img4.jpg
+5,1,N Miami/Biscayne,12055 Biscayne Blvd,,33181,Florida,Miami,United States,25.88674000,-80.16329200,,,,,09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;09:00 - 19:00;10:00 - 16:00;10:00 - 16:00,http://yourlinktotheimage.com/img5.jpg


### PR DESCRIPTION
Related to https://github.com/thirtybees/thirtybees/issues/1462

Inverted separators - errors are thrown for 'working hours' and the import does not complete with error:

Errors occurred:
Store is invalid (Dade County)
Property Store->hours is not valid
Store is invalid (E Fort Lauderdale)
Property Store->hours is not valid
Store is invalid (Pembroke Pines)
Property Store->hours is not valid
Store is invalid (Coconut Grove)
Property Store->hours is not valid
Store is invalid (N Miami/Biscayne)
Property Store->hours is not valid.

The issue is at line: 4463:

```
if (isset($store->hours) && is_array($store->hours)) {
            $store->hours = serialize($store->hours);
        }
```

Proposed fix:

```
// Handle hours field
        if (isset($info['hours']) && is_string($info['hours'])) {
            // Convert the CSV string to an array using ; as the delimiter
            $hoursArray = explode(';', $info['hours']);
            $store->hours = json_encode($hoursArray);
        } elseif (isset($store->hours) && is_array($store->hours)) {
            $store->hours = json_encode($store->hours);
        }
```
