### PR TITLE
fix: Undefined index: premium in Module class

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -965,7 +965,7 @@ abstract class ModuleCore
 
                 if (isset($modulesNameToCursor[mb_strtolower(strval($name))])) {
                     $moduleFromList = $modulesNameToCursor[mb_strtolower(strval($name))];
-                    $moduleFromList->premium = $module['premium'];
+                    $moduleFromList->premium = (!isset($module['premium'])) ? '' : $module['premium'];
                     if ($moduleFromList->canInstall && $moduleFromList->premium) {
                         $allowedTypes = array_column($moduleFromList->premium, 'type');
                         $moduleFromList->canInstall = in_array($supporterType, $allowedTypes, true);
@@ -1005,7 +1005,7 @@ abstract class ModuleCore
                     'need_instance'       => 0,
                     'not_on_disk'         => 1,
                     'active'              => 0,
-                    'premium'             => $module['premium'],
+                    'premium'             => (!isset($module['premium'])) ? '' : $module['premium'],
                     'canInstall'          => (bool)$module['binary'],
                     'url'                 => $module['url'] ?? ''
                 ];


### PR DESCRIPTION
Many notifications invoked on multiple BO pages (Modules, Performance,...) about:
...
_Notice on line 1008 in file classes/module/Module.php
[8] Undefined index: premium
Notice on line 968 in file classes/module/Module.php
[8] Undefined index: premium_
...
![issue-module-premium-index-missing](https://github.com/deweblooper/thirtybees/assets/57491379/4bb1c7ae-a9e5-4e34-8bed-416773b1dadb)

  
Store information
	Thirty bees version: 1.6.0
	Thirty bees revision: da60bc83138149de660a37a0c27c874d61e50102
	Build for PHP version: 7.4
	Shop URL: localhost
	Current theme in use: Niara

Server information
	Server information: Windows NT build 18362 (Windows 10) AMD64
	Server software version: Apache/2.4.59 (Win64) OpenSSL/3.1.5 PHP/7.4.33
	PHP version: 7.4.33
	Memory limit: 1024M
	Max execution time: 480

Database information
	MySQL version: 10.8.3-MariaDB
	MySQL server: localhost
	MySQL name: ***
	MySQL user: ***
	Tables prefix: ***
	MySQL engine: InnoDB
	MySQL driver: PDO

Your information
	Your web browser: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/119.0
	
Check your configuration
	Required parameters: OK
	Optional parameters: OK