### PR TITLE
ShopMaintenance - delete old lines in /error_log and /admin/error_log

### DIFF
--- a/controllers/admin/AdminPerformanceController.php
+++ b/controllers/admin/AdminPerformanceController.php
@@ -359,7 +359,7 @@ class AdminPerformanceControllerCore extends AdminController
                 [
                     'type'   => 'text',
                     'label'  => $this->l('Log files retention period'),
-                    'desc'  => $this->l('Number of days to keep log files in /log/ directory'),
+                    'desc'  => $this->l('Number of days to keep old log files in /log/ directory and old lines in /error_log and /admin_folder/error_log files. Recommended value: 180.'),
                     'name'   => Configuration::LOGS_RETENTION_PERIOD,
                 ],
             ],
@@ -659,7 +659,7 @@ class AdminPerformanceControllerCore extends AdminController
                 [
                     'type'   => 'text',
                     'label'  => $this->l('Keep JS and CSS files'),
-                    'desc'  => $this->l('Number of days to keep old JS and CSS files on the server, to make sure e.g. Google\'s cache still renders it correctly. Enter zero if you don\'t want to keep old files'),
+                    'desc'  => $this->l('Number of days to keep old JS and CSS files on the server, to make sure e.g. Google\'s cache still renders it correctly. Recommended value: 180. Enter zero if you don\'t want to keep old files.'),
                     'name'   => Configuration::CCC_ASSETS_RETENTION_PERIOD,
                 ],
             ],


### PR DESCRIPTION
Reused getLogsRetentionPeriod constant as it basically applies to those logs too.

Delete old lines and leaves those after the cutoff date.

Line by line approach for old uncleaned files that could be MB in size - should save RAM on first run.

This method appears to work with errors that don't start with a timestamp (Mail queue module) as it checks the next line for retention and removes anything above it. So even if the file is manually edited this approach should handle it.

Restores last modified date for easier debugging when looking purely on the date.