### PR TITLE
Cast int on image entities

### DIFF
--- a/classes/ImageEntity.php
+++ b/classes/ImageEntity.php
@@ -313,11 +313,11 @@ class ImageEntityCore extends ObjectModel
 
             if ($withImageTypes) {
                 $imageEntities[$name]['imageTypes'][] = [
-                    'id_image_type' => $res['id_image_type'],
+                    'id_image_type' => (int)$res['id_image_type'],
                     'name' => $res['image_type'],
-                    'width' => $res['width'],
-                    'height' => $res['height'],
-                    'id_image_type_parent' => $res['id_image_type_parent'],
+                    'width' => (int)$res['width'],
+                    'height' => (int)$res['height'],
+                    'id_image_type_parent' => (int)$res['id_image_type_parent'],
                 ];
             }
 


### PR DESCRIPTION
When creating array of image entities we need to cast int where needed.
later this array is being used in ```generateImageTypesByEntity``` when generating new images.
this function is checking if alias exists to skip generate of image => ```if ($imageType['id_image_type_parent'])```
and this will pass (when it shouldn't) on a default string value of '0'