### PR TITLE
Spell check help block

### DIFF
--- a/admin-dev/themes/default/template/controllers/products/associations.tpl
+++ b/admin-dev/themes/default/template/controllers/products/associations.tpl
@@ -38,6 +38,8 @@
 			<div id="category_block">
 				{$category_tree}
 			</div>
+			<div class="help-block">{l s='You can safely remove the Home category association if you have another default one and you don\'t use the Featured Products module. The Home category should not be the default one, as this might hurt your user experience and SEO.'}
+			</div>
 			<a class="btn btn-link bt-icon confirm_leave" href="{$link->getAdminLink('AdminCategories')|escape:'html':'UTF-8'}&amp;addcategory">
 				<i class="icon-plus-sign"></i> {l s='Create new category'} <i class="icon-external-link-sign"></i>
 			</a>

--- a/admin-dev/themes/default/template/controllers/products/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/products/informations.tpl
@@ -395,6 +395,8 @@
 				{capture}<a class="addImageDescription" href="javascript:void(0);">{l s='Click here'}</a>{/capture}
 				{l s='Would you like to add an image in your description? %s and paste the given tag in the description.' sprintf=$smarty.capture.default}
 			</div>
+			<div class="help-block">{l s='In order to use the browser\'s spell check, please use CTRL + right click over the underlined word.'}
+			</div>
 		</div>
 	</div>
 	<div id="createImageDescription" class="panel" style="display:none">
@@ -458,7 +460,7 @@
 		<label class="control-label col-lg-3" for="tags_{$id_lang}">
 			<span class="label-tooltip" data-toggle="tooltip"
 				title="{l s='Will be displayed in the tags block when enabled. Tags help customers easily find your products.'}">
-				{l s='Tags:'}
+				{l s='Tags'}
 			</span>
 		</label>
 		<div class="col-lg-9">


### PR DESCRIPTION
Clarification how to use the browser's spell check in TinyMCE.

The colon is removed from 'Tags:' in order to unify the captions in this page.