### PR TITLE
Longer ExpiresByType for gif, jp(e)g, png, webp, css, js. Added avif …

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3314,14 +3314,15 @@ class ToolsCore
         if ($cache_control) {
             $cache_control = "<IfModule mod_expires.c>
 	ExpiresActive On
-	ExpiresByType image/gif \"access plus 1 month\"
-	ExpiresByType image/jpeg \"access plus 1 month\"
-	ExpiresByType image/png \"access plus 1 month\"
-	ExpiresByType image/webp \"access plus 1 month\"
-	ExpiresByType text/css \"access plus 1 week\"
-	ExpiresByType text/javascript \"access plus 1 week\"
-	ExpiresByType application/javascript \"access plus 1 week\"
-	ExpiresByType application/x-javascript \"access plus 1 week\"
+	ExpiresByType image/gif \"access plus 1 year\"
+	ExpiresByType image/jpeg \"access plus 1 year\"
+	ExpiresByType image/png \"access plus 1 year\"
+	ExpiresByType image/webp \"access plus 1 year\"
+        ExpiresByType image/avif \"access plus 1 year\"
+	ExpiresByType text/css \"access plus 1 year\"
+	ExpiresByType text/javascript \"access plus 1 year\"
+	ExpiresByType application/javascript \"access plus 1 year\"
+	ExpiresByType application/x-javascript \"access plus 1 year\"
 	ExpiresByType image/x-icon \"access plus 1 year\"
 	ExpiresByType image/svg+xml \"access plus 1 year\"
 	ExpiresByType image/vnd.microsoft.icon \"access plus 1 year\"


### PR DESCRIPTION
…MIME type.

In 2024 all website speed test services complain about short future expire period.

If your system does not set the proper expiration dates for avif, please check if the server has it as configured MIME type.