### PR TITLE
Add new Hook and fix nesting

### DIFF
--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -217,5 +217,5 @@
 		{l s='For this particular customer group, prices are displayed as:'} <b>{if $tax_calculation_method == $smarty.const.PS_TAX_EXC}{l s='Tax excluded'}{else}{l s='Tax included'}{/if}</b>
 	</div>
 	{hook h="displayAdminCartFooter" id_cart=$cart->id|intval}
-{/block}
 </div>
+{/block}

--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -216,5 +216,6 @@
 	<div class="row alert alert-warning">
 		{l s='For this particular customer group, prices are displayed as:'} <b>{if $tax_calculation_method == $smarty.const.PS_TAX_EXC}{l s='Tax excluded'}{else}{l s='Tax included'}{/if}</b>
 	</div>
+	{hook h="displayAdminCartFooter" id_cart=$cart->id|intval}
 {/block}
 </div>


### PR DESCRIPTION
Some modules may want to display more info about specific cart, but currently there is no way to hook any module to cart details. 