### PR TITLE
Adding id_supply_order to BO list

### DIFF
--- a/controllers/admin/AdminSupplyOrdersController.php
+++ b/controllers/admin/AdminSupplyOrdersController.php
@@ -81,6 +81,12 @@ class AdminSupplyOrdersControllerCore extends AdminController
         $this->list_no_link = true;
 
         $this->fields_list = [
+            'id_supply_order'        => [
+                'title' => $this->l('ID'),
+                'align' => 'center',
+                'class' => 'fixed-width-xs',
+                'type'  => 'int',
+            ],
             'reference'              => [
                 'title'        => $this->l('Reference'),
                 'havingFilter' => true,


### PR DESCRIPTION
This PR just adds the id_supply_order column to the Backoffice list of supply orders. Most merchants don't use this feature, but if you do, it's annoying to work without the primary id. 

Imagine in product list you would have to work only with reference and not id_product. It would suck, right?