### PR TITLE
Dynamically size the attribute list

### DIFF
--- a/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
+++ b/admin-dev/themes/default/template/controllers/attribute_generator/content.tpl
@@ -76,7 +76,7 @@
 		<div class="row">
 			<div class="col-lg-3">
 				<div class="form-group">
-					<select multiple name="attributes[]" id="attribute_group" style="height: 500px">
+					<select multiple name="attributes[]" id="attribute_group" style="height: 65vh">
 						{foreach $attribute_groups as $k => $attribute_group}
 							{if isset($attribute_js[$attribute_group['id_attribute_group']])}
 								<optgroup name="{$attribute_group['id_attribute_group']}" id="{$attribute_group['id_attribute_group']}" label="{$attribute_group['name']|escape:'html':'UTF-8'}">


### PR DESCRIPTION
Resize the window based on viewport size and show more attributes when possible.

Not increased more so not to push the buttons under the fold on smaller resolutions (1920x1080@125% - 15" laptops or 1920x1080@100% - 20+" monitors).