### PR TITLE
Remove ISO from default language URL when multilang.

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -293,14 +293,21 @@ class LinkCore
             $context = Context::getContext();
         }
 
-        if ((!$this->allow && in_array($idShop, [$context->shop->id, null])) || !Language::isMultiLanguageActivated($idShop) || !(int) Configuration::get('PS_REWRITING_SETTINGS', null, null, $idShop)) {
-            return '';
-        }
-
         if (!$idLang) {
             $idLang = $context->language->id;
         }
 
+        // Check conditions for returning an empty string in the URL
+        if ((!$this->allow && in_array($idShop, [$context->shop->id, null])) 
+            || !Language::isMultiLanguageActivated($idShop) 
+            || !(int) Configuration::get('PS_REWRITING_SETTINGS', null, null, $idShop)
+            || ($idLang == Configuration::get('PS_LANG_DEFAULT') 
+                && Configuration::get('TB_REMOVE_DEFAULT_LANGUAGE_ISO_URL', null, null, $idShop))
+        ) {
+            return '';
+        }
+
+        // Return the ISO code of the language
         return Language::getIsoById($idLang).'/';
     }
 

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -180,6 +180,15 @@ class AdminMetaControllerCore extends AdminController
                 'cast' => 'intval',
                 'type' => 'bool',
             ];
+
+            $generalFields['TB_REMOVE_DEFAULT_LANGUAGE_ISO_URL'] = [
+                'title' => $this->l('Remove ISO code in the default language URLs'),
+                'desc' => $this->l('When multiple languages are enabled in the store, all URLs automatically include the language\'s ISO code (e.g., /en/ for English).') . '<br/>' . 
+                         $this->l('If your store initially has only one language, the URLs won\'t include an ISO code. However, if you later add another language, enabling this option is recommended to maintain the SEO integrity of your default language.'),
+                'validation' => 'isBool',
+                'cast' => 'intval',
+                'type' => 'bool',
+            ];
         } else {
             $urlDescription = $this->l('Before you can use this tool, you need to:');
             $urlDescription .= $this->l('1) Create a blank .htaccess file in your root directory.');


### PR DESCRIPTION
Related to: https://github.com/thirtybees/thirtybees/issues/1920

Known bug:
- when switching from default to non-default language - it is working
- when switching back - the shop is stuck on the non-default language.