### PR TITLE
Fix imports containing non-printable chars in names

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2546,11 +2546,16 @@ class AdminImportControllerCore extends AdminController
         $validLink = Validate::isLinkRewrite($linkRewrite);
         if (!$validLink) {
             if (isset($product->name[$idLang])) {
-                $productName = $product->name[$idLang] ?? '';
-                $linkRewrite = Tools::link_rewrite($product->name[$idLang] ?? '');
-                if ($linkRewrite == '') {
+                $productName = trim($product->name[$idLang] ?? '');
+                $product->name[$idLang] = $productName;
+                $product->validateFields();
+                $linkRewrite = Tools::link_rewrite($product->name[$idLang]);
+
+                if (!Validate::isLinkRewrite($linkRewrite)) {
                     $linkRewrite = 'friendly-url-autogeneration-failed';
                 }
+
+                $product->link_rewrite[$idLang] = $linkRewrite;
 
                 $this->informations[] = sprintf(
                     $this->l('Rewrite link for %1$s (ID %2$s): re-written as %3$s.'),


### PR DESCRIPTION
Attempt to fix https://github.com/thirtybees/thirtybees/issues/1890

Manual product generation returns proper URL but importing a CSV with product names containing non-printable chars (U+A0) leads to empty spaces in the slug and thus unsuccessful product import. Attempted to use native methods.