### PR TITLE
Allow to override ImageManager's resize method.

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -640,12 +640,12 @@ class ImageManagerCore
                     }
 
                     $dstFile = $baseName . '-' . stripslashes($imageType['name']) . '.' . $defaultImageExtension;
-                    $success = self::resize($sourceImage, $dstFile, $imageType['width'], $imageType['height'], $defaultImageExtension) && $success;
+                    $success = static::resize($sourceImage, $dstFile, $imageType['width'], $imageType['height'], $defaultImageExtension) && $success;
 
                     // Only generate if size of sourceImage is big enough
                     if (self::retinaSupport() && (($sourceWidth >= $imageType['width'] * 2) || ($sourceHeight >= $imageType['height'] * 2))) {
                         $dstFileRetina = $baseName . '-' . stripslashes($imageType['name']) . '2x.' . $defaultImageExtension;
-                        $success = self::resize($sourceImage, $dstFileRetina, $imageType['width'] * 2, $imageType['height'] * 2, $defaultImageExtension) && $success;
+                        $success = static::resize($sourceImage, $dstFileRetina, $imageType['width'] * 2, $imageType['height'] * 2, $defaultImageExtension) && $success;
                     }
                 }
 


### PR DESCRIPTION
This update allows you to override the ImageManager resizing method.

Reason
I have a plenty of images of varying sizes and aspect ratios and I found that the custom zoom/crop functionality is the best option for my store. I couldn't achieve the same behavior using the default resize method, hence this update.