### PR TITLE
Dynamic robots.txt - attempt 2

### DIFF
--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -753,6 +753,17 @@ class DispatcherCore
         switch ($this->front_controller) {
             // Dispatch front office controller
             case static::FC_FRONT:
+            
+                 // Handle robots.txt without relying on URL rewriting
+                if (strtolower($_SERVER['REQUEST_URI']) === '/robots.txt') {
+                    require_once _PS_ROOT_DIR_ . '/controllers/front/RobotsController.php';
+
+                    // Instantiate RobotsController directly
+                    $controller = new RobotsController();
+                    $controller->run();
+                    exit; // Stop further processing
+                }
+                
                 $controllers = Dispatcher::getControllers([_PS_FRONT_CONTROLLER_DIR_, _PS_OVERRIDE_DIR_.'controllers/front/']);
                 $controllers['index'] = 'IndexController';
                 if (isset($controllers['auth'])) {

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -1121,8 +1121,7 @@ class AdminMetaControllerCore extends AdminController
         $sitemapFile = _PS_ROOT_DIR_.'/'.$shop->id.'_index_sitemap.xml';
         if (file_exists($sitemapFile)) {
             $content .= "# Sitemap\n";
-            $content .= 'Sitemap: '.(Configuration::get('PS_SSL_ENABLED') ? 'https://' : 'http://')
-                .$shop->domain.__PS_BASE_URI__.$shop->id.'_index_sitemap.xml'."\n";
+            $content .= 'Sitemap: ' . $shop->getBaseURL() . $shop->id . '_index_sitemap.xml' . "\n";
         }
 
         $this->saveRobotsContent($id_shop, $content);

--- a/controllers/admin/AdminMetaController.php
+++ b/controllers/admin/AdminMetaController.php
@@ -269,7 +269,7 @@ class AdminMetaControllerCore extends AdminController
         $this->fields_options['robots'] = [
             'title'       => $this->l('Robots.txt Management'),
             'icon'        => 'icon-cogs',
-            'description' => $this->l("Edit the robots.txt file for this shop. WARNING: when using Multistore, ensure you edit this section individually for each shop, as certain records might be unique to each shop. Please note that thirtybees 1.7 and later does not utilize a traditional robots.txt file in the root folder, instead, the records are stored in the database table. Neverthless you should have robots.php file in your root folder which facilitates this."),
+            'description' => $this->l("Edit the robots.txt file for this shop. WARNING: when using Multistore, ensure you edit this section individually for each shop, as certain records might be unique to each shop. Please note that thirtybees 1.7 and later does not utilize a traditional robots.txt file in the root folder, instead, the records are stored in the database table. Neverthless you should have robots.php file in your root folder which facilitates this. Don't forget to regenerate robots.txt when turning ON Friendly URLs."),
             'fields'      => [
                 'robots_content' => [
                     'title' => $this->l('robots.txt Content'),
@@ -1104,13 +1104,16 @@ class AdminMetaControllerCore extends AdminController
 
         // Add files
         if (!empty($robots_data['Files'])) {
-            $activeLanguageCount = count(Language::getIDs());
+            $defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
             $content .= "# Files\n";
             foreach ($robots_data['Files'] as $isoCode => $files) {
                 foreach ($files as $file) {
-                    if ($activeLanguageCount > 1) {
+                    $id_lang = (int) Language::getIdByIso($isoCode);
+                    if ($id_lang !== $defaultLanguageId) {
+                        // Only add ISO code for non-default languages
                         $content .= "Disallow: /$isoCode/$file\n";
                     } else {
+                        // Add without ISO code for the default language
                         $content .= "Disallow: /$file\n";
                     }
                 }
@@ -1121,7 +1124,7 @@ class AdminMetaControllerCore extends AdminController
         $sitemapFile = _PS_ROOT_DIR_.'/'.$shop->id.'_index_sitemap.xml';
         if (file_exists($sitemapFile)) {
             $content .= "# Sitemap\n";
-            $content .= 'Sitemap: ' . $shop->getBaseURL() . $shop->id . '_index_sitemap.xml' . "\n";
+            $content .= 'Sitemap: ' . $shop->getBaseURL(true) . $shop->id . '_index_sitemap.xml' . "\n";
         }
 
         $this->saveRobotsContent($id_shop, $content);

--- a/controllers/front/RobotsController.php
+++ b/controllers/front/RobotsController.php
@@ -1,5 +1,33 @@
 <?php
-
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2025 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ *  @author    thirty bees <contact@thirtybees.com>
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2017-2025 thirty bees
+ *  @copyright 2007-2016 PrestaShop SA
+ *  @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
 class RobotsController extends FrontController
 {
     public $php_self = 'robots';
@@ -131,7 +159,7 @@ class RobotsController extends FrontController
             }
 
             // Append the correct Sitemap URL for this shop
-            $sitemapUrl = ($shop['ssl'] ? 'https://' : 'http://') . $shop['domain'] . $shop['physical_uri'] . $id_shop . '_index_sitemap.xml';
+            $sitemapUrl = Context::getContext()->shop->getBaseURL() . $id_shop . '_index_sitemap.xml';
             $finalContent = $cleanedContent . "\nSitemap: " . $sitemapUrl;
 
             // Add the data to the batch insert array

--- a/controllers/front/RobotsController.php
+++ b/controllers/front/RobotsController.php
@@ -1,0 +1,206 @@
+<?php
+
+class RobotsController extends FrontController
+{
+    public $php_self = 'robots';
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        // Run migration and setup only if not already completed
+        if (!Configuration::get('ROBOTS_MIGRATION_DONE')) {
+            $this->migrateAndSetup();
+            Configuration::updateValue('ROBOTS_MIGRATION_DONE', 1);
+        }
+
+        // Fetch robots.txt content for the current shop
+        $id_shop = (int) Context::getContext()->shop->id;
+        $robots_content = Db::getInstance()->getValue(
+            'SELECT robots_content
+             FROM ' . _DB_PREFIX_ . 'robots
+             WHERE id_shop = ' . $id_shop
+        );
+
+        // Send robots.txt content
+        header('Content-Type: text/plain');
+        header('X-Content-Type-Options: nosniff');
+
+        if ($robots_content) {
+            echo $robots_content;
+        } else {
+            // Log the missing robots.txt content for this shop
+            $message = sprintf('No robots.txt content found for shop ID: %d. Please fix this in your SEO & URLs section.', $id_shop);
+            error_log($message);
+
+            // Optionally log to Collect Logs module
+            if (class_exists('Logger')) {
+                Logger::addLog($message, 3, null, 'RobotsController', null, true); // Severity 3 = Warning
+            }
+
+            // Send fallback robots.txt
+            echo "User-agent: *\n";
+            echo "Allow: /modules/*.css\n";
+            echo "Allow: /modules/*.js\n";
+            echo "Disallow: */classes/\n";
+            echo "Disallow: */config/\n";
+            echo "Disallow: */download/\n";
+            echo "Disallow: */mails/\n";
+            echo "Disallow: */translations/\n";
+            echo "Disallow: */tools/\n";
+        }
+
+        die();
+    }
+
+    /**
+     * Perform migration and setup.
+     */
+    private function migrateAndSetup()
+    {
+        // Step 1: Ensure robots table exists
+        $this->ensureRobotsTableExists();
+
+        // Step 2: Migrate robots.txt file contents into the robots table for all shops
+        $this->migrateRobotsTxtToTable();
+
+        // Step 3: Ensure 'robots' entry exists in the meta table
+        $this->ensureMetaEntryExists();
+
+        // Step 4: Ensure SEO URLs exist in meta_lang table for all shops and languages
+        $this->ensureSeoUrlsExist();
+    }
+
+    /**
+     * Ensure the robots table exists.
+     */
+    private function ensureRobotsTableExists()
+    {
+        // Check if the robots table exists and create it if it doesn't
+        $sql = 'CREATE TABLE IF NOT EXISTS ' . _DB_PREFIX_ . 'robots (
+                    id_shop INT UNSIGNED NOT NULL,
+                    robots_content TEXT NOT NULL,
+                    PRIMARY KEY (id_shop)
+                ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4';
+
+        if (Db::getInstance()->execute($sql)) {
+            // Log successful table creation (only if it was created for the first time)
+            if (class_exists('Logger')) {
+                Logger::addLog('Checked and ensured existence of the robots table.', 1, null, 'RobotsController', null, true);
+            }
+        } else {
+            // Log failure to create table
+            $errorMessage = 'Failed to create or ensure the existence of the robots table.';
+            if (class_exists('Logger')) {
+                Logger::addLog($errorMessage, 3, null, 'RobotsController', null, true);
+            }
+            error_log($errorMessage);
+        }
+    }
+
+    /**
+     * Migrate contents of robots.txt into the robots table for all shops.
+     */
+    private function migrateRobotsTxtToTable()
+    {
+        $robotsFilePath = _PS_ROOT_DIR_ . '/robots.txt';
+
+        // Check if robots.txt exists
+        if (!file_exists($robotsFilePath)) {
+            return; // No file to migrate
+        }
+
+        $fileContents = file_get_contents($robotsFilePath);
+        $sitemapRegex = '/Sitemap:.*/i'; // Regex to find Sitemap entries
+        $cleanedContent = preg_replace($sitemapRegex, '', $fileContents); // Clean the file once instead of per shop
+
+        $shops = Shop::getShops(false);
+
+        // Prepare the insert query for multiple rows
+        $dataToInsert = [];
+        foreach ($shops as $shop) {
+            $id_shop = (int) $shop['id_shop'];
+
+            // Check if robots content already exists for this shop
+            $exists = Db::getInstance()->getValue(
+                'SELECT 1 FROM ' . _DB_PREFIX_ . 'robots WHERE id_shop = ' . $id_shop
+            );
+
+            if ($exists) {
+                continue; // Skip migration if content already exists
+            }
+
+            // Append the correct Sitemap URL for this shop
+            $sitemapUrl = ($shop['ssl'] ? 'https://' : 'http://') . $shop['domain'] . $shop['physical_uri'] . $id_shop . '_index_sitemap.xml';
+            $finalContent = $cleanedContent . "\nSitemap: " . $sitemapUrl;
+
+            // Add the data to the batch insert array
+            $dataToInsert[] = [
+                'id_shop' => $id_shop,
+                'robots_content' => pSQL($finalContent, true),
+            ];
+        }
+
+        // Perform batch insert if there are entries to insert
+        if (!empty($dataToInsert)) {
+            Db::getInstance()->insert('robots', $dataToInsert);
+        }
+
+        // Rename the robots.txt file to robots.txt.old after migration
+        $newRobotsFilePath = _PS_ROOT_DIR_ . '/robots.txt.old';
+        if (!rename($robotsFilePath, $newRobotsFilePath)) {
+            // Log the error if renaming fails
+            if (class_exists('Logger')) {
+                Logger::addLog('Failed to rename robots.txt to robots.txt.old', 3, null, 'RobotsController', null, true);
+            }
+            error_log('Failed to rename robots.txt to robots.txt.old');
+        }
+    }
+
+    /**
+     * Ensure the 'robots' entry exists in the meta table.
+     */
+    private function ensureMetaEntryExists()
+    {
+        // Attempt to insert the 'robots' entry if it doesn't exist
+        $insertQuery = '
+            INSERT IGNORE INTO ' . _DB_PREFIX_ . 'meta (page, configurable)
+            VALUES ("robots", 0)
+        ';
+        Db::getInstance()->execute($insertQuery);
+    }
+
+    /**
+     * Ensure SEO URLs exist in the meta_lang table for all shops and languages.
+     */
+    private function ensureSeoUrlsExist()
+    {
+        $id_meta = Db::getInstance()->getValue(
+            'SELECT id_meta
+             FROM ' . _DB_PREFIX_ . 'meta
+             WHERE page = "robots"'
+        );
+
+        if (!$id_meta) {
+            return; // Safety check, should not happen
+        }
+
+        $shops = Shop::getShops(false);
+        $languages = Language::getLanguages(false);
+
+        foreach ($shops as $shop) {
+            foreach ($languages as $language) {
+                $id_lang = (int) $language['id_lang'];
+                $id_shop = (int) $shop['id_shop'];
+
+                // Use raw SQL with interpolated values
+                $insertQuery = '
+                    INSERT IGNORE INTO ' . _DB_PREFIX_ . 'meta_lang (id_meta, id_lang, id_shop, url_rewrite, title)
+                    VALUES (' . (int) $id_meta . ', ' . $id_lang . ', ' . $id_shop . ', "robots.txt", "robots.txt")
+                ';
+
+                Db::getInstance()->execute($insertQuery);
+            }
+        }
+    }
+}

--- a/install-dev/data/xml/meta.xml
+++ b/install-dev/data/xml/meta.xml
@@ -144,6 +144,10 @@
 			<page>products-comparison</page>
 			<configurable>1</configurable>
 		</meta>
+		<meta id="robots">
+			<page>robots</page>
+			<configurable>0</configurable>
+		</meta>
 		<meta id="search">
 			<page>search</page>
 			<configurable>1</configurable>


### PR DESCRIPTION
A second attempt, hopefully better.

1. Migration starts by accessing index.php?controller=robots
- this creates the needed records for tables meta, meta_lang, robots and a record in Configuration for completed migration and setup.
2. The migration will look for robots.txt, copy it's contents in robots table and correct the sitemap url per shop (currently it's same for all shops). At the end a record is set that the migration is done and original robots.txt file is renamed robots.txt.old
3. We're using dispatcher to forward all calls to robots.txt to RobotsController which serves values from the table or if not present (migration is uncomplete because of missing robots.txt altogether) it serves conservative code and logs an error in BO so merchant hopefully sees it and generate the table entries by using the button.

I have the following bugs.
1. Migration should be started manually by accessing index.php?controller=robots. If this is not done robots.txt will continue to be served with precedence. I am unable to think how this can be avoided without using redirects.
2. Robots.txt contents in SEO & URLs acts funny and displays old/cached info, not the actual table entry upon refresh. I'm unable to find the bug.
3. I don't know how to add robots table to the golden files for new installs.
4. I don't know how to log to CollectLogs module too.

Potential issues:
1. SEO Optimization modules for PS could look for robots.txt in order to edit it. No such modules as far as I know for thirtybees for now.