### PR TITLE
Show name of shop in order view if Multistore is enabled

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -112,6 +112,9 @@
           {l s='Order'}
           <span class="badge">{$order->reference}</span>
           <span class="badge">{l s="#"}{$order->id}</span>
+          {if $shop_feature_active|default:false}
+            <span class="badge">{$shop_name}</span>
+          {/if}
           <div class="panel-heading-action">
             <div class="btn-group">
               <a class="btn btn-default{if !$previousOrder} disabled{/if}" href="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}&amp;vieworder&amp;id_order={$previousOrder|intval}">

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1843,7 +1843,15 @@ class AdminOrdersControllerCore extends AdminController
         if (!Validate::isLoadedObject($order)) {
             $this->errors[] = Tools::displayError('The order cannot be found within your database.');
         }
-
+        
+        $shopActive = Shop::isFeatureActive();
+        if ($shopActive) {
+            $shop = new Shop((int)$order->id_shop);
+            $this->tpl_view_vars['shop_name'] = $shop->name;
+        }
+        $this->tpl_view_vars['shop_feature_active'] = $shopActive;
+        $this->context->smarty->assign($this->tpl_view_vars);
+        
         $customer = new Customer($order->id_customer);
         $carrier = new Carrier($order->id_carrier);
         $products = $this->getProducts($order);


### PR DESCRIPTION
When in order view we can't see anywhere the shop name when multistore is enabled.

And if we need to call the customer and start the conversation with 'Hello, we're calling from XYZ store' we have to go to the order list, get the shop name, get in the order again, etc.

I think it's a nice use of this free space and its not shown if Multistore is not used.

![image](https://github.com/user-attachments/assets/21722985-7fdc-4037-ac65-13f4eea2e232)
