### PR TITLE
Db backup fix

### DIFF
--- a/classes/ShopMaintenance.php
+++ b/classes/ShopMaintenance.php
@@ -183,11 +183,35 @@ class ShopMaintenanceCore
      */
     public static function autoDbBackup()
     {
-        if (Configuration::get('TB_DB_AUTO_BACKUP')) {
+        if (Configuration::get('TB_BACKUP_RUNNING')) {
+            return;
+        }
+        
+        Configuration::updateValue('TB_BACKUP_RUNNING', 1);
+        
+        try {
             $backup = new PrestaShopBackup();
             if ($backup->add()) {
-                PrestaShopLogger::addLog('Automatic backup created: ' . basename($backup->id), 1, null, 'ShopMaintenance', null, true);
+                PrestaShopLogger::addLog(
+                    'Automatic backup created: ' . basename($backup->id),
+                    1,
+                    null,
+                    'ShopMaintenance',
+                    null,
+                    true
+                );
             }
+        } catch (Exception $e) {
+            PrestaShopLogger::addLog(
+                'Backup error: ' . $e->getMessage(),
+                3,
+                null,
+                'ShopMaintenance',
+                null,
+                true
+            );
+        } finally {
+            Configuration::updateValue('TB_BACKUP_RUNNING', 0);
         }
     }
     

--- a/classes/ShopMaintenance.php
+++ b/classes/ShopMaintenance.php
@@ -183,7 +183,7 @@ class ShopMaintenanceCore
      */
     public static function autoDbBackup()
     {
-        if (Configuration::get('TB_BACKUP_RUNNING')) {
+        if (!Configuration::get('TB_DB_AUTO_BACKUP') || Configuration::get('TB_BACKUP_RUNNING')) {
             return;
         }
         


### PR DESCRIPTION
Previously a concurrent execution was possible when page refreshes during active backup or if multiple employees are logged at the same time.