### PR TITLE
Upgrade Cart.php > getProducts improvement

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -643,8 +643,16 @@ class CartCore extends ObjectModel
                 }
             }
 
-            $row['reduction_applies'] = ($specificPriceOutput && (float) $specificPriceOutput['reduction']);
-            $row['quantity_discount_applies'] = ($specificPriceOutput && $quantity >= (int) $specificPriceOutput['from_quantity']);
+            $row['reduction_applies'] = null;
+            if ($specificPriceOutput && $specificPriceOutput['reduction'] && $specificPriceOutput['reduction_type']) {
+                if ($specificPriceOutput['reduction_type'] == 'amount') {
+                    $row['reduction_applies'] = $specificPriceOutput['reduction'];
+                } elseif ($specificPriceOutput['reduction_type'] == 'percentage') {
+                    $row['reduction_applies'] = round((float) $specificPriceOutput['reduction'] * 100);
+                }
+            }
+
+            $row['quantity_discount_applies'] = (int) ($specificPriceOutput['from_quantity'] ?? 0);
             $row['allow_oosp'] = Product::isAvailableWhenOutOfStock($row['out_of_stock']);
             $row['features'] = Product::getFeaturesStatic((int) $row['id_product']);
 


### PR DESCRIPTION
The getProducts function returns a list of products with parameters. Some of these parameters are not used anywhere at all and are actually useless.

This modification changes several of these parameters so that a promising practical opportunity to use them in templates appears. 

For example, in the Ajax cart you can now display discounts (-15% or -26$) and show messages to the users like "add to cart N qty to cart to apply discount.".

Without additional queries from template or module.