### PR TITLE
Convert PNG palette images to true color on creation

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -409,8 +409,10 @@ class ImageManagerCore
                 imagepalettetotruecolor($resource); // Otherwise gif to webp can lead in fatal error
                 return $resource;
 
-            case IMAGETYPE_PNG :
-                return imagecreatefrompng($filename);
+            case IMAGETYPE_PNG:
+                $resource = imagecreatefrompng($filename);
+                imagepalettetotruecolor($resource);
+                return $resource;
 
             case IMAGETYPE_WEBP:
                 return imagecreatefromwebp($filename);


### PR DESCRIPTION
Convert PNG palette images to true color on creation to avoid issues on saving to different formats. Solves #2032.