### PR TITLE
Fix warning during attachment upload

### DIFF
--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -284,7 +284,6 @@ class AdminAttachmentsControllerCore extends AdminController
                             $this->errors[] = $this->l('Failed to copy the file.');
                         }
                         $_POST['file_name'] = $_FILES['file']['name'];
-                        @unlink($_FILES['file']['tmp_name']);
                         if (!count($this->errors) && isset($a) && file_exists($a->getFilePath())) {
                             @unlink($a->getFilePath());
                         }


### PR DESCRIPTION
We're trying to unlink a temp file after move_uploaded_file during attachment upload.

Related to https://github.com/thirtybees/thirtybees/issues/2039