### PR TITLE
AdminCustomersController - fix Default customer group list

### DIFF
--- a/controllers/admin/AdminCustomersController.php
+++ b/controllers/admin/AdminCustomersController.php
@@ -628,7 +628,7 @@ class AdminCustomersControllerCore extends AdminController
                     'label'   => $this->l('Default customer group'),
                     'name'    => 'id_default_group',
                     'options' => [
-                        'query' => $groups,
+                        'query' => [],
                         'id'    => 'id_group',
                         'name'  => 'name',
                     ],
@@ -736,6 +736,19 @@ class AdminCustomersControllerCore extends AdminController
             $customerGroupsIds = array_merge($customerGroupsIds, $preselected);
         }
 
+        $defaultGroups = [];
+        foreach ($groups as $group) {
+            if (in_array($group['id_group'], $customerGroupsIds)) {
+                $defaultGroups[] = $group;
+            }
+        }
+        foreach ($this->fields_form['input'] as &$input) {
+            if ($input['type'] === 'select' && $input['name'] === 'id_default_group') {
+                $input['options']['query'] = $defaultGroups;
+                break;
+            }
+        }
+
         foreach ($groups as $group) {
             $this->fields_value['groupBox_'.$group['id_group']] =
                 Tools::getValue('groupBox_'.$group['id_group'], in_array($group['id_group'], $customerGroupsIds));
@@ -752,6 +765,7 @@ class AdminCustomersControllerCore extends AdminController
     {
         parent::setMedia();
         $this->addJqueryPlugin(['typewatch', 'fancybox']);
+        $this->addJS(_PS_JS_DIR_.'admin/customers.js');
     }
 
     /**
@@ -1361,6 +1375,90 @@ class AdminCustomersControllerCore extends AdminController
             }
             $this->ajaxDie('ok');
         }
+    }
+
+    /**
+     * Update customer groups
+     *
+     * @return void
+     *
+     * @throws PrestaShopException
+     */
+    public function ajaxProcessUpdateCustomerGroups()
+    {
+        if (!$this->hasEditPermission()) {
+            if (!headers_sent()) {
+                header('Content-Type: application/json; charset=utf-8');
+            }
+            $this->ajaxDie(json_encode([
+                'success' => false,
+                'message' => $this->l('You do not have permission to edit this.'),
+                'groups'  => [],
+            ]));
+        }
+
+        $idCustomer = Tools::getIntValue('id_customer');
+        $groupIds   = Tools::getValue('groupBox');
+        $groupIds   = is_array($groupIds) ? array_map('intval', $groupIds) : [];
+
+        if (empty($groupIds)) {
+            if (!headers_sent()) {
+                header('Content-Type: application/json; charset=utf-8');
+            }
+            $this->ajaxDie(json_encode([
+                'success' => false,
+                'message' => $this->l('A customer must belong to at least one group.'),
+                'groups'  => [],
+            ]));
+        }
+
+        $customer = new Customer($idCustomer);
+        if (!Validate::isLoadedObject($customer)) {
+            if (!headers_sent()) {
+                header('Content-Type: application/json; charset=utf-8');
+            }
+            $this->ajaxDie(json_encode([
+                'success' => false,
+                'message' => $this->l('Unable to load customer.'),
+                'groups'  => [],
+            ]));
+        }
+
+        // Determine the default group: keep if still associated, otherwise switch to the first posted group
+        $newDefault = in_array((int)$customer->id_default_group, $groupIds)
+            ? (int)$customer->id_default_group
+            : (int)reset($groupIds);
+
+        // Save associations
+        $customer->updateGroup($groupIds);
+
+        // Persist new default if it changed
+        if ($newDefault !== (int)$customer->id_default_group) {
+            $customer->id_default_group = $newDefault;
+            $customer->update();
+        }
+
+        // Build list for dropdown (associated groups only)
+        $groups = [];
+        $allGroups = Group::getGroups($this->context->language->id, true);
+        foreach ($allGroups as $g) {
+            if (in_array((int)$g['id_group'], $groupIds, true)) {
+                $groups[] = [
+                    'id_group' => (int)$g['id_group'],
+                    'name'     => $g['name'],
+                ];
+            }
+        }
+
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+        }
+        $this->ajaxDie(json_encode([
+            'success'    => true,
+            'message'    => $this->l('Group associations updated.'),
+            'groups'     => $groups,
+            'id_default' => $newDefault,
+        ]));
     }
 
     /**

--- a/js/admin/customers.js
+++ b/js/admin/customers.js
@@ -1,0 +1,158 @@
+/**
+ * 2007-2016 PrestaShop
+ *
+ * thirty bees is an extension to the PrestaShop e-commerce software developed by PrestaShop SA
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.thirtybees.com for more information.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2017-2024 thirty bees
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
+ */
+
+$(function () {
+
+  // Handle the master header checkbox that calls checkDelBoxes(...)
+  // It toggles all .groupBox without firing 'change', so we enforce at least one
+  // and then trigger the normal change flow to sync server.
+  $(document).on('click', 'input[type="checkbox"][onclick*="checkDelBoxes"][onclick*="groupBox"]', function () {
+    setTimeout(function () {
+      var $all = $('.groupBox');
+      var $checked = $all.filter(':checked');
+
+      if ($checked.length === 0) {
+        var def = $('#id_default_group').val();
+        if (def && $all.filter('[value="' + def + '"]').length) {
+          $all.filter('[value="' + def + '"]').prop('checked', true);
+        } else if ($all.length) {
+          $all.first().prop('checked', true);
+        }
+
+        // red popup
+        if (typeof showErrorMessage === 'function') {
+          showErrorMessage(window.i18n_at_least_one_group || 'A customer must belong to at least one group.');
+        } else if ($.growl && $.growl.error) {
+          $.growl.error({ title: '', message: window.i18n_at_least_one_group || 'A customer must belong to at least one group.' });
+        }
+      }
+
+      // trigger our normal handler so associations are saved
+      var $trigger = $('.groupBox:checked').first();
+      if ($trigger.length) {
+        $trigger.trigger('change');
+      } else if ($all.length) {
+        $all.first().trigger('change');
+      }
+    }, 0);
+  });
+
+  // Individual group checkbox handler
+  $('.groupBox').on('change', function () {
+    var $changed = $(this);
+    var idCustomer = $('input[name="id_customer"]').val();
+    if (!idCustomer) {
+      return;
+    }
+
+    var groups = $('.groupBox:checked').map(function () { return $(this).val(); }).get();
+
+    if (groups.length === 0) {
+      // popup (red)
+      if (typeof showErrorMessage === 'function') {
+        showErrorMessage(window.i18n_at_least_one_group || 'A customer must belong to at least one group.');
+      } else if ($.growl && $.growl.error) {
+        $.growl.error({ title: '', message: window.i18n_at_least_one_group || 'A customer must belong to at least one group.' });
+      }
+      // revert the last toggle
+      $changed.prop('checked', !$changed.prop('checked'));
+      return;
+    }
+
+    $.ajax({
+      type: 'POST',
+      url: window.currentIndex + '&ajax=1&action=updateCustomerGroups&token=' + window.token,
+      dataType: 'json',
+      data: { id_customer: idCustomer, 'groupBox': groups }
+    })
+    .done(function (data) {
+      // error from controller
+      if (!data || data.success === false) {
+        var msg = (data && data.message) ? data.message : (window.i18n_groups_failed || 'Could not update groups.');
+        if (typeof showErrorMessage === 'function') {
+          showErrorMessage(msg);
+        } else if ($.growl && $.growl.error) {
+          $.growl.error({ title: '', message: msg });
+        }
+        // revert checkbox state
+        $changed.prop('checked', !$changed.prop('checked'));
+        return;
+      }
+
+      if (!Array.isArray(data.groups) || data.groups.length === 0) {
+        var m = (data && data.message) ? data.message : (window.i18n_at_least_one_group || 'A customer must belong to at least one group.');
+        if (typeof showErrorMessage === 'function') {
+          showErrorMessage(m);
+        } else if ($.growl && $.growl.error) {
+          $.growl.error({ title: '', message: m });
+        }
+        $changed.prop('checked', !$changed.prop('checked'));
+        return;
+      }
+
+      // rebuild the "Default customer group" select
+      var $sel = $('#id_default_group');
+      $sel.empty();
+      $.each(data.groups, function (i, g) {
+        $('<option/>').val(g.id_group).text(g.name).appendTo($sel);
+      });
+
+      // select the server-sent default (covers the case when old default was removed)
+      if (typeof data.id_default !== 'undefined' && $sel.find('option[value="' + data.id_default + '"]').length) {
+        $sel.val(String(data.id_default));
+      } else {
+        var prev = $sel.data('prev') || null;
+        if (prev && $sel.find('option[value="' + prev + '"]').length) {
+          $sel.val(prev);
+        } else {
+          $sel.prop('selectedIndex', 0);
+        }
+      }
+      $sel.data('prev', $sel.val());
+
+      // green popup
+      if (typeof showSuccessMessage === 'function') {
+        showSuccessMessage(window.i18n_groups_updated || (data.message || 'Group associations updated.'));
+      } else if ($.growl && $.growl.notice) {
+        $.growl.notice({ title: '', message: window.i18n_groups_updated || (data.message || 'Group associations updated.') });
+      }
+    })
+    .fail(function () {
+      var msg = window.i18n_groups_failed || 'Could not update groups.';
+      if (typeof showErrorMessage === 'function') {
+        showErrorMessage(msg);
+      } else if ($.growl && $.growl.error) {
+        $.growl.error({ title: '', message: msg });
+      }
+      $changed.prop('checked', !$changed.prop('checked'));
+    });
+  });
+
+});


### PR DESCRIPTION
Default customer group should show only currently selected groups to choose from. Now it shows all groups and if we choose a one not associated with the account and save there is an error.

- optimized the logic of the dropdown list
- introduced ajax call to dynamically update the list based on the marked checkboxes of Group access list (no need to save and reenter the account profile to choose the new default)
- notification popup for error/success