### PR TITLE
Carrier price bug

### DIFF
--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -727,14 +727,22 @@ class CarrierCore extends ObjectModel implements InitializationCallback
                 unset($carrierList[$key]);
             }
 
-            if ($carrier->min_total > 0 && ($carrier->min_total > $cart->getOrderTotal($carrier->min_total_tax, Cart::BOTH_WITHOUT_SHIPPING))) {
-                $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
-                unset($carrierList[$key]);
+            if ($carrier->min_total > 0) {
+                $orderTotal = $cart->getOrderTotal($carrier->min_total_tax, Cart::BOTH_WITHOUT_SHIPPING);
+                $orderTotal = Tools::convertPrice($orderTotal, $cart->id_currency, false);
+                if ($carrier->min_total > $orderTotal) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }
             }
 
-            if ($carrier->max_total > 0 && ($carrier->max_total < $cart->getOrderTotal($carrier->max_total_tax, Cart::BOTH_WITHOUT_SHIPPING))) {
-                $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
-                unset($carrierList[$key]);
+            if ($carrier->max_total > 0) {
+                $orderTotal = $cart->getOrderTotal($carrier->max_total_tax, Cart::BOTH_WITHOUT_SHIPPING);
+                $orderTotal = Tools::convertPrice($orderTotal, $cart->id_currency, false);
+                if ($carrier->max_total < $orderTotal) {
+                    $error[$carrier->id] = static::SHIPPING_PRICE_EXCEPTION;
+                    unset($carrierList[$key]);
+                }
             }
 
             if ($carrier->min_weight > 0 && $cartWeight < $carrier->min_weight) {


### PR DESCRIPTION
Thanks to beetea2 for reporting this bug here: https://forum.thirtybees.com/topic/7490-free-shipping-ecb-exchange-module/#findComment-51874

Repro steps: merchant wants to offer shipping pricing per weight up to 60 USD and then free delivery for all orders. The solution is  to make 2 copies of the same carrier - first with pricing by weight up to 60 and then second one with price by total:

```
Paid shipping -> page 2 -> Handling costs NO, Free shipping NO, Billing by weight, Out of range: Apply the highest cost. I have 4 weight ranges set up. 

Page 3 -> Minimum order value US$0 Maximum Order value US$60

Free shipping -> page 2 -> Free shipping YES, Billing by price, Out of range: Disable. All zones selected.

Page 3 -> Minimum order US$60 Maximum order set at 0.00 to disable.

With this set up, an order of US$46 is required to pay a shipping charge. If the currency is changed to CAD with no changes in the cart the order now costs CAD$63.68 and gets free shipping.

Localization -> Currencies USD exchange rate 1 CAD exchange rate 1.384437

Perhaps the problem comes from the Free shipping option on page 2?
```

During checkout if client switches to other currency than the default one they will get free delivery (disable the first carrier, enable the second FREE carrier) only when they reach the same amount in the new currency. The conversion rate is not respected.