### PR TITLE
Allow multiple attachments to customer messages

### DIFF
--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
@@ -53,14 +53,25 @@
 			</h4>
 		{/if}
 		<span class="message-date">&nbsp;<i class="icon-calendar"></i> - {dateFormat date=$message.date_add full=0} - <i class="icon-time"></i> {$message.date_add|substr:11:5}</span>
-		{if $message.file_name}
-			<span class="message-product">
-				&nbsp;<i class="icon-link"></i>
-				<a href="{$link->getAdminLink('AdminCustomerThreads', true, ['showMessageAttachment' => $message.id_customer_message])|escape:'htmlall':'UTF-8'}" target="_blank">
-					{l s="Attachment"}
-				</a>
-			</span>
-		{/if}
+                {if isset($message.attachments) && count($message.attachments)}
+                        <div class="message-attachment">
+                                <strong>{l s='Attached files:'}</strong>
+                                <ul class="list-unstyled">
+                                        {foreach from=$message.attachments item=attachment}
+                                                <li>
+                                                        <i class="icon-paperclip"></i>
+                                                        {if isset($attachment.stored_name)}
+                                                                <a href="{$link->getAdminLink('AdminCustomerThreads', true, ['showMessageAttachment' => $message.id_customer_message, 'attachment' => $attachment.stored_name])|escape:'htmlall':'UTF-8'}" target="_blank">
+                                                                        {$attachment.original_name|default:$attachment.stored_name|escape:'html':'UTF-8'}
+                                                                </a>
+                                                        {else}
+                                                                {$attachment.original_name|default:$attachment.stored_name|escape:'html':'UTF-8'}
+                                                        {/if}
+                                                </li>
+                                        {/foreach}
+                                </ul>
+                        </div>
+                {/if}
 		{if isset($message.product_name)} <span class="message-attachment">&nbsp;<i class="icon-book"></i> <a href="{$message.product_link|escape:'html':'UTF-8'}" class="_blank">{l s="Product:"} {$message.product_name|escape:'html':'UTF-8'} </a></span>{/if}
 		<p class="message-item-text">{$message.message|escape:'html':'UTF-8'|nl2br}</p>
 	</div>

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -127,8 +127,8 @@
 					<textarea cols="30" rows="7" id="txt_msg" name="reply_message">{$PS_CUSTOMER_SERVICE_SIGNATURE|escape:'html':'UTF-8'}</textarea>
 					<div class="row" style="margin-top:10px;">
 						<div class="col-sm-12 form-inline">
-							<label for="file_attachment" class="control-label">{l s='Attach file'}</label>
-							<input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                                                        <label for="file_attachment" class="control-label">{l s='Attach file'}</label>
+                                                        <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple="multiple">
 						</div>
 					</div>
 				</div>

--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -836,6 +836,25 @@
                   <p class="message-item-text">
                     {$message['message']|escape:'html':'UTF-8'|nl2br}
                   </p>
+                  {if isset($message.attachments) && count($message.attachments)}
+                    <div class="message-attachment">
+                      <strong>{l s='Attached files:'}</strong>
+                      <ul class="list-unstyled">
+                        {foreach from=$message.attachments item=attachment}
+                          <li>
+                            <i class="icon-paperclip"></i>
+                            {if isset($attachment.stored_name)}
+                              <a href="{$link->getAdminLink('AdminCustomerThreads', true, ['showMessageAttachment' => $message.id_customer_message, 'attachment' => $attachment.stored_name])|escape:'htmlall':'UTF-8'}" target="_blank">
+                                {$attachment.original_name|default:$attachment.stored_name|escape:'html':'UTF-8'}
+                              </a>
+                            {else}
+                              {$attachment.original_name|default:$attachment.stored_name|escape:'html':'UTF-8'}
+                            {/if}
+                          </li>
+                        {/foreach}
+                      </ul>
+                    </div>
+                  {/if}
                 </div>
                 {*if ($message['is_new_for_me'])}
                   <a class="new_message" title="{l s='Mark this message as \'viewed\''}" href="{$smarty.server.REQUEST_URI}&amp;token={$smarty.get.token}&amp;messageReaded={$message['id_message']}">
@@ -907,7 +926,7 @@
               <div class="form-group">
                 <label class="control-label col-lg-3">{l s='Attach file'}</label>
                 <div class="col-lg-9">
-                  <input type="file" id="file_attachment" name="file_attachment" class="form-control">
+                  <input type="file" id="file_attachment" name="file_attachment[]" class="form-control" multiple="multiple">
                 </div>
               </div>
 

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4254,17 +4254,45 @@ FileETag none
     public static function fileAttachment($input = 'fileUpload', $return_content = true)
     {
         $file_attachment = null;
-        if (!empty($_FILES[$input]['name']) && !empty($_FILES[$input]['tmp_name'])) {
-            $file_attachment['rename'] = uniqid().mb_strtolower(substr($_FILES[$input]['name'], -5));
-            if ($return_content) {
-                $file_attachment['content'] = file_get_contents($_FILES[$input]['tmp_name']);
-            }
-            $file_attachment['tmp_name'] = $_FILES[$input]['tmp_name'];
-            $file_attachment['name'] = $_FILES[$input]['name'];
-            $file_attachment['mime'] = $_FILES[$input]['type'];
-            $file_attachment['error'] = $_FILES[$input]['error'];
-            $file_attachment['size'] = $_FILES[$input]['size'];
+
+        if (empty($_FILES[$input]['name']) || empty($_FILES[$input]['tmp_name'])) {
+            return $file_attachment;
         }
+
+        if (is_array($_FILES[$input]['name'])) {
+            foreach ($_FILES[$input]['name'] as $index => $name) {
+                if (empty($name) || empty($_FILES[$input]['tmp_name'][$index])) {
+                    continue;
+                }
+
+                $attachment = [
+                    'rename'   => uniqid().mb_strtolower(substr($name, -5)),
+                    'tmp_name' => $_FILES[$input]['tmp_name'][$index],
+                    'name'     => $name,
+                    'mime'     => $_FILES[$input]['type'][$index] ?? null,
+                    'error'    => $_FILES[$input]['error'][$index] ?? null,
+                    'size'     => $_FILES[$input]['size'][$index] ?? null,
+                ];
+
+                if ($return_content) {
+                    $attachment['content'] = file_get_contents($_FILES[$input]['tmp_name'][$index]);
+                }
+
+                $file_attachment[] = $attachment;
+            }
+
+            return $file_attachment;
+        }
+
+        $file_attachment['rename'] = uniqid().mb_strtolower(substr($_FILES[$input]['name'], -5));
+        if ($return_content) {
+            $file_attachment['content'] = file_get_contents($_FILES[$input]['tmp_name']);
+        }
+        $file_attachment['tmp_name'] = $_FILES[$input]['tmp_name'];
+        $file_attachment['name'] = $_FILES[$input]['name'];
+        $file_attachment['mime'] = $_FILES[$input]['type'];
+        $file_attachment['error'] = $_FILES[$input]['error'];
+        $file_attachment['size'] = $_FILES[$input]['size'];
 
         return $file_attachment;
     }

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -740,7 +740,7 @@ CREATE TABLE `PREFIX_customer_message` (
   `id_customer_thread` int(11) DEFAULT NULL,
   `id_employee` int(11) unsigned DEFAULT NULL,
   `message` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `file_name` varchar(18) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `file_name` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `ip_address` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `user_agent` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `date_add` datetime NOT NULL,


### PR DESCRIPTION
Related to: https://github.com/thirtybees/thirtybees/issues/2077 and https://github.com/thirtybees/thirtybees/issues/2078

-allow customer service and order message forms to upload multiple attachments and persist their metadata
-render attached files beneath messages with download links for each stored file
-extend attachment parsing utilities and database schema to handle multiple stored filenames