### PR TITLE
Add support for displaying the customer message in the delivery slip PDF

### DIFF
--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -144,8 +144,6 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
             unset($orderDetail); // don't overwrite the last order_detail later
         }
 
-        $message = $this->order->getFirstMessage();
-        
         $this->smarty->assign(
             [
                 'order'                  => $this->order,
@@ -155,7 +153,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
                 'order_invoice'          => $this->order_invoice,
                 'carrier'                => $carrier,
                 'display_product_images' => Configuration::get('PS_PDF_IMG_DELIVERY'),
-                'customer_message'       => $message,
+                'customer_message'       => $this->order->getFirstMessage(),
             ]
         );
 

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -144,6 +144,8 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
             unset($orderDetail); // don't overwrite the last order_detail later
         }
 
+        $message = $this->order->getFirstMessage();
+
         $this->smarty->assign(
             [
                 'order'                  => $this->order,
@@ -153,6 +155,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
                 'order_invoice'          => $this->order_invoice,
                 'carrier'                => $carrier,
                 'display_product_images' => Configuration::get('PS_PDF_IMG_DELIVERY'),
+                'customer_message'       => $message,
             ]
         );
 

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -145,11 +145,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
         }
 
         $message = $this->order->getFirstMessage();
-        if (strlen($message) > 1000)
-        {
-            $message = substr($message, 0, 1000) . "...";
-        }
-
+        
         $this->smarty->assign(
             [
                 'order'                  => $this->order,

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -145,6 +145,10 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
         }
 
         $message = $this->order->getFirstMessage();
+        if (strlen($message) > 1000)
+        {
+            $message = substr($message, 0, 1000) . "...";
+        }
 
         $this->smarty->assign(
             [

--- a/pdf/delivery-slip.summary-tab.tpl
+++ b/pdf/delivery-slip.summary-tab.tpl
@@ -41,7 +41,7 @@
 		<tr>
 			<td class="center small white" colspan="3">
 				<b>{l s='Customer Message' pdf='true'}</b><br/>
-				{$customer_message}
+				{$customer_message|truncate:1000:'...'}
 			</td>
 		</tr>
 	{/if}

--- a/pdf/delivery-slip.summary-tab.tpl
+++ b/pdf/delivery-slip.summary-tab.tpl
@@ -40,7 +40,6 @@
 	{if $customer_message}
 		<tr>
 			<td class="center small white" colspan="3">
-				<br/><br/>
 				<b>{l s='Customer Message' pdf='true'}</b><br/>
 				{$customer_message}
 			</td>

--- a/pdf/delivery-slip.summary-tab.tpl
+++ b/pdf/delivery-slip.summary-tab.tpl
@@ -37,5 +37,14 @@
 			<td class="center small white">{$carrier->name}</td>
 		{/if}
 	</tr>
+	{if $customer_message}
+		<tr>
+			<td class="center small white" colspan="3">
+				<br/><br/>
+				<b>{l s='Customer Message' pdf='true'}</b><br/>
+				{$customer_message}
+			</td>
+		</tr>
+	{/if}
 </table>
 


### PR DESCRIPTION
For businesses who use the delivery slip as a packing slip showing the customers message for that order on the delivery slip can be critical. This PR adds support to display the message related to the order on the delivery slip. 

It will be displayed as such:
<img width="928" height="147" alt="image" src="https://github.com/user-attachments/assets/f9a63105-e489-4330-91bc-67f720595f96" />

With string lmiting (1000 chars): 
<img width="927" height="221" alt="image" src="https://github.com/user-attachments/assets/6df1bb76-0d8d-4f98-b473-b5479f38d3e7" />


Open to feedback, this is the code I use on my ThirtyBees 1.6 instance.