### PR TITLE
Add configuration option for rendering PDFs inline instead of as attachment

### DIFF
--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -135,7 +135,11 @@ class AdminPdfControllerCore extends AdminController
     public function generatePDF($object, $template)
     {
         $pdf = new PDF($object, $template, $this->context->smarty);
-        $pdf->render();
+        
+        if (Configuration::get('PS_DISPLAY_PDF_INLINE'))
+            $pdf->render("I");
+        else 
+            $pdf->render();
     }
 
     /**

--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -136,7 +136,7 @@ class AdminPdfControllerCore extends AdminController
     {
         $pdf = new PDF($object, $template, $this->context->smarty);
         
-        if (Configuration::get('PS_DISPLAY_PDF_INLINE'))
+        if (Configuration::get('TB_DISPLAY_PDF_INLINE'))
             $pdf->render("I");
         else 
             $pdf->render();

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -226,7 +226,7 @@ class AdminPreferencesControllerCore extends AdminController
                         'class'        => 'fixed-width-sm',
                         'defaultValue' => ','
                     ],
-                    'PS_DISPLAY_PDF_INLINE'     => [
+                    'TB_DISPLAY_PDF_INLINE'     => [
                         'title'      => $this->l('Display PDFs Inline'),
                         'desc'       => $this->l('Render PDFs (product attachments, invoices, delivery slips, etc) inline instead of as an attachment'),
                         'validation' => 'isBool',

--- a/controllers/admin/AdminPreferencesController.php
+++ b/controllers/admin/AdminPreferencesController.php
@@ -226,6 +226,13 @@ class AdminPreferencesControllerCore extends AdminController
                         'class'        => 'fixed-width-sm',
                         'defaultValue' => ','
                     ],
+                    'PS_DISPLAY_PDF_INLINE'     => [
+                        'title'      => $this->l('Display PDFs Inline'),
+                        'desc'       => $this->l('Render PDFs (product attachments, invoices, delivery slips, etc) inline instead of as an attachment'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                 ]
             );
 

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -60,10 +60,12 @@ class AttachmentControllerCore extends FrontController
             ob_end_clean();
         }
 
+        $disposition = Configuration::get('PS_DISPLAY_PDF_INLINE') ? "inline" : "attachment";
+
         header('Content-Transfer-Encoding: binary');
         header('Content-Type: '.$a->mime);
         header('Content-Length: '.filesize($a->getFilePath()));
-        header('Content-Disposition: attachment; filename="'.mb_convert_encoding($a->file_name, 'ISO-8859-1', 'UTF-8').'"');
+        header('Content-Disposition: '.$disposition.'; filename="'.mb_convert_encoding($a->file_name, 'ISO-8859-1', 'UTF-8').'"');
         @set_time_limit(0);
         readfile($a->getFilePath());
         exit;

--- a/controllers/front/AttachmentController.php
+++ b/controllers/front/AttachmentController.php
@@ -60,7 +60,7 @@ class AttachmentControllerCore extends FrontController
             ob_end_clean();
         }
 
-        $disposition = Configuration::get('PS_DISPLAY_PDF_INLINE') ? "inline" : "attachment";
+        $disposition = Configuration::get('TB_DISPLAY_PDF_INLINE') ? "inline" : "attachment";
 
         header('Content-Transfer-Encoding: binary');
         header('Content-Type: '.$a->mime);


### PR DESCRIPTION
Add a configuration option for allowing PDFs to render as inline instead of attachment. 

We frequently print delivery slips, it is annoying to download each one to print. This PR adds a configuration option under Preferences > General for rendering PDFs as inline instead of as attachment. 

I am unaware if I missed any locations.