### PR TITLE
New hook for rendering buttons in the admin orders page

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/helpers/view/view.tpl
@@ -176,6 +176,7 @@
               {l s='Partial refund'}
             </a>
           {/if}
+          {$HOOK_TAB_ORDER_BUTTONS}
         </div>
         <!-- Tab nav -->
         <ul class="nav nav-tabs" id="tabOrder">

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -2047,6 +2047,14 @@ class AdminOrdersControllerCore extends AdminController
                     'customer' => $customer,
                 ]
             ),
+            'HOOK_TAB_ORDER_BUTTONS'      => Hook::displayHook(
+                'displayAdminOrderButtons',
+                [
+                    'order'    => $order,
+                    'products' => $products,
+                    'customer' => $customer,
+                ]
+            ),
             'HOOK_TAB_SHIP'                => Hook::displayHook(
                 'displayAdminOrderTabShip', [
                     'order'    => $order,

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -74,7 +74,7 @@
       <name>displayAdminOrderTabOrder</name><title>Display new elements in Back Office, AdminOrder, panel Order</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
     </hook>
     <hook id="displayAdminOrderButtons" live_edit="0">
-      <name>displayAdminOrderButtons</name><title>Display buttons in the order page</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
+      <name>displayAdminOrderButtons</name><title>Display buttons in the order page</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and adds additional buttons</description>
     </hook>
     <hook id="displayAdminOrderTabShip" live_edit="0">
       <name>displayAdminOrderTabShip</name><title>Display new elements in Back Office, AdminOrder, panel Shipping</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel tabs</description>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -73,6 +73,9 @@
     <hook id="displayAdminOrderTabOrder" live_edit="0">
       <name>displayAdminOrderTabOrder</name><title>Display new elements in Back Office, AdminOrder, panel Order</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
     </hook>
+    <hook id="displayAdminOrderButtons" live_edit="0">
+      <name>displayAdminOrderButtons</name><title>Display buttons in the order page</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Order panel tabs</description>
+    </hook>
     <hook id="displayAdminOrderTabShip" live_edit="0">
       <name>displayAdminOrderTabShip</name><title>Display new elements in Back Office, AdminOrder, panel Shipping</title><description>This hook launches modules when the AdminOrder tab is displayed in the Back Office and extends / override Shipping panel tabs</description>
     </hook>


### PR DESCRIPTION
New hook for adding custom buttons to the admin orders page!
<img width="917" height="153" alt="image" src="https://github.com/user-attachments/assets/24300871-2110-441c-ab3c-39baa1f85e5d" />

There is already a hook for adding to the tabs, I believe there should also be a hook for modules to register buttons on this page. 

As you can see I've added a couple custom buttons myself, most notably a direct link to the paypal/strip order, as well as a button to launch a window for generating a shipping label.