### PR TITLE
Preserve script attributes when moving to end

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -670,7 +670,7 @@ class FrontControllerCore extends Controller
             $this->context->smarty->assign(
                 [
                     'js_def' => Media::getJsDef(),
-                    'js_files' => $defer ? array_unique($this->js_files) : [],
+                    'js_files' => $defer ? Media::getDeferredScripts($this->js_files) : [],
                     'js_inline' => ($defer && $domAvailable) ? Media::getInlineScript() : [],
                 ]
             );

--- a/themes/javascript.tpl
+++ b/themes/javascript.tpl
@@ -51,7 +51,11 @@ var {$k} = '{$def|@addcslashes:'\''}';
 {/if}
 {if isset($js_files) && $js_files|@count}
 {foreach from=$js_files key=k item=js_uri}
+{if is_array($js_uri)}
+<script{if !empty($js_uri.attrs)}{$js_uri.attrs}{/if} src="{$js_uri.src}"></script>
+{else}
 <script src="{$js_uri}"></script>
+{/if}
 {/foreach}
 {/if}
 {if isset($js_inline) && $js_inline|@count}


### PR DESCRIPTION
Related to: https://github.com/thirtybees/thirtybees/issues/1233

* Preserve script attributes when deferring

* Preserve deferred script attributes per occurrence

* Render deferred script attributes before src