### PR TITLE
Mulstistore: Cart should be viewed in own shop context

### DIFF
--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -72,7 +72,7 @@
 			{else}
 				<h2>{l s='No order was created from this cart.'}</h2>
 				{if $customer->id}
-					<a class="btn btn-default" href="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}&amp;id_cart={$cart->id|intval}&amp;addorder"><i class="icon-shopping-cart"></i> {l s='Create an order from this cart.'}</a>
+					<a class="btn btn-default" href="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}&amp;id_cart={$cart->id|intval}&amp;addorder&amp;setShopContext=s-{$cart->id_shop|intval}"><i class="icon-shopping-cart"></i> {l s='Create an order from this cart.'}</a>
 				{/if}
 			{/if}
 		</div>

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -286,6 +286,21 @@ class AdminCartsControllerCore extends AdminController
         if (!($cart = $this->loadObject(true))) {
             return '';
         }
+
+        // Ensure the cart is viewed in its own shop context (runtime-only).
+        $idCartShop = (int)$cart->id_shop;
+        if (
+            Shop::isFeatureActive()
+            && $idCartShop > 0
+            && $this->context->employee->hasAuthOnShop($idCartShop)
+        ) {
+            Shop::setContext(Shop::CONTEXT_SHOP, $idCartShop);
+
+            if (!Validate::isLoadedObject($this->context->shop) || (int)$this->context->shop->id !== $idCartShop) {
+                $this->context->shop = new Shop($idCartShop);
+            }
+        }
+
         $customer = new Customer($cart->id_customer);
         $currency = new Currency($cart->id_currency);
         $this->context->cart = $cart;


### PR DESCRIPTION
Currently in Multistore we're loading carts in All shop context by using the default shop's settings. This can lead to wrong data on this page.

Also appended proper shop context to the Create an order from this cart button so we are not seeing an error if we are not in it. Unfortunately this approach  is 'sticky' and merchant has to switch back to All shops context if needed after order completion.