### PR TITLE
Allow back-office order creation from guest carts

### DIFF
--- a/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl
@@ -71,9 +71,7 @@
 				{l s='Made on:'} {dateFormat date=$order->date_add}
 			{else}
 				<h2>{l s='No order was created from this cart.'}</h2>
-				{if $customer->id}
-					<a class="btn btn-default" href="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}&amp;id_cart={$cart->id|intval}&amp;addorder"><i class="icon-shopping-cart"></i> {l s='Create an order from this cart.'}</a>
-				{/if}
+				<a class="btn btn-default" href="{$link->getAdminLink('AdminOrders')|escape:'html':'UTF-8'}&amp;id_cart={$cart->id|intval}&amp;addorder"><i class="icon-shopping-cart"></i> {l s='Create an order from this cart.'}</a>
 			{/if}
 		</div>
 	</div>

--- a/admin-dev/themes/default/template/controllers/orders/form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/form.tpl
@@ -45,6 +45,9 @@
   var priceDisplayPrecision = 0; {* Set in displaySummary(). *}
   var priceDatabasePrecision = {$smarty.const._TB_PRICE_DATABASE_PRECISION_};
   var request = null;
+	var txt_missing_customer_before_create = '{l s='You must select or create a customer before creating the order.' js=1}';
+	var initial_cart_id = {$cart->id|intval};
+	var is_cart_from_visitor = (initial_cart_id > 0 && {$cart->id_customer|intval} <= 0);
 
 	{foreach from=$defaults_order_state key='module' item='id_order_state'}
 		defaults_order_state['{$module}'] = '{$id_order_state}';
@@ -124,8 +127,18 @@
 				add_cart_rule(data.id_cart_rule);
 			});
 		{if $cart->id}
-			setupCustomer({$cart->id_customer|intval});
-			useCart('{$cart->id|intval}');
+			$('#id_cart').val(initial_cart_id);
+			if (is_cart_from_visitor) {
+				$('#carts').hide();
+				$('#products_part').show();
+				$('#vouchers_part').show();
+				$('#address_part').show();
+				$('#carriers_part').show();
+				$('#summary_part').show();
+			} else {
+				setupCustomer({$cart->id_customer|intval});
+			}
+			useCart(initial_cart_id);
 		{/if}
 
 		$('.delete_product').live('click', function(e) {
@@ -249,12 +262,20 @@
 			return false;
 		});
 
+		$('form:has(button[name="submitAddOrder"])').on('submit', function(e){
+			if (parseInt(id_customer, 10) <= 0) {
+				e.preventDefault();
+				showMissingCustomerError();
+				return false;
+			}
+		});
+
 		$('#products_found').hide();
 		$('#carts').hide();
 
 		$('#customer_part').on('click','button.setup-customer',function(e){
 			e.preventDefault();
-			setupCustomer($(this).data('customer'));
+			setupCustomer($(this).data('customer'), is_cart_from_visitor);
 			$(this).removeClass('setup-customer').addClass('change-customer').html('<i class="icon-refresh"></i>&nbsp;{l s="Change"}').blur();
 			$(this).closest('.customerCard').addClass('selected-customer');
 			$('.selected-customer .panel-heading').prepend('<i class="icon-ok text-success"></i>');
@@ -281,6 +302,13 @@
 			$(this).blur();
 		});
 	});
+
+	function showMissingCustomerError()
+	{
+		$('#missing_customer_error').remove();
+		$('<div id="missing_customer_error" class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">&times;</button>'+txt_missing_customer_before_create+'</div>').insertBefore($('.panel').first());
+		$('html, body').animate({ldelim}scrollTop: 0{rdelim}, 200);
+	}
 
 	function resetBind()
 	{
@@ -525,9 +553,9 @@
 	}
 
 
-	function setupCustomer(idCustomer)
+	function setupCustomer(idCustomer, preserveCurrentCart)
 	{
-		$('#carts').show();
+		$('#missing_customer_error').remove();
 		$('#products_part').show();
 		$('#vouchers_part').show();
 		$('#address_part').show();
@@ -535,8 +563,20 @@
 		$('#summary_part').show();
 		var address_link = $('#new_address').attr('href');
 		id_customer = idCustomer;
-		id_cart = 0;
 		$('#new_address').attr('href', address_link.replace(/id_customer=[0-9]+/, 'id_customer='+id_customer));
+
+		if (preserveCurrentCart) {
+			$('#carts').hide();
+			if (initial_cart_id > 0) {
+				id_cart = initial_cart_id;
+				$('#id_cart').val(id_cart);
+				useCart(id_cart);
+			}
+			return;
+		}
+
+		$('#carts').show();
+		id_cart = 0;
 		$.ajax({
 			type:"POST",
 			url : "{$link->getAdminLink('AdminCarts')|addslashes}",

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -278,9 +278,6 @@ class AdminOrdersControllerCore extends AdminController
         if ($idCart && !Validate::isLoadedObject($cart)) {
             $this->errors[] = $this->l('This cart does not exists');
         }
-        if ($idCart && Validate::isLoadedObject($cart) && !$cart->id_customer) {
-            $this->errors[] = $this->l('The cart must have a customer');
-        }
         if (count($this->errors)) {
             return;
         }
@@ -1344,32 +1341,36 @@ class AdminOrdersControllerCore extends AdminController
                 $paymentModule = $this->getPaymentModule();
 
                 $cart = new Cart((int) $idCart);
-                $this->context->currency = new Currency((int) $cart->id_currency);
-                $this->context->customer = new Customer((int) $cart->id_customer);
-
-                if (($badDelivery = !Address::isCountryActiveById((int) $cart->id_address_delivery))
-                    || !Address::isCountryActiveById((int) $cart->id_address_invoice)
-                ) {
-                    if ($badDelivery) {
-                        $this->errors[] = Tools::displayError('This delivery address country is not active.');
-                    } else {
-                        $this->errors[] = Tools::displayError('This invoice address country is not active.');
-                    }
+                if (!(int) $cart->id_customer) {
+                    $this->errors[] = Tools::displayError('You must select a customer before creating the order.');
                 } else {
-                    $employee = new Employee((int) $this->context->cookie->id_employee);
-                    $paymentModule->validateOrder(
-                        (int) $cart->id,
-                        (int) $idOrderState,
-                        $cart->getOrderTotal(true, Cart::BOTH),
-                        $paymentModule->displayName,
-                        $this->l('Manual order -- Employee:').' '.substr($employee->firstname, 0, 1).'. '.$employee->lastname,
-                        [],
-                        null,
-                        false,
-                        $cart->secure_key
-                    );
-                    if ($paymentModule->currentOrder) {
-                        Tools::redirectAdmin(static::$currentIndex.'&id_order='.$paymentModule->currentOrder.'&vieworder'.'&token='.$this->token);
+                    $this->context->currency = new Currency((int) $cart->id_currency);
+                    $this->context->customer = new Customer((int) $cart->id_customer);
+
+                    if (($badDelivery = !Address::isCountryActiveById((int) $cart->id_address_delivery))
+                        || !Address::isCountryActiveById((int) $cart->id_address_invoice)
+                    ) {
+                        if ($badDelivery) {
+                            $this->errors[] = Tools::displayError('This delivery address country is not active.');
+                        } else {
+                            $this->errors[] = Tools::displayError('This invoice address country is not active.');
+                        }
+                    } else {
+                        $employee = new Employee((int) $this->context->cookie->id_employee);
+                        $paymentModule->validateOrder(
+                            (int) $cart->id,
+                            (int) $idOrderState,
+                            $cart->getOrderTotal(true, Cart::BOTH),
+                            $paymentModule->displayName,
+                            $this->l('Manual order -- Employee:').' '.substr($employee->firstname, 0, 1).'. '.$employee->lastname,
+                            [],
+                            null,
+                            false,
+                            $cart->secure_key
+                        );
+                        if ($paymentModule->currentOrder) {
+                            Tools::redirectAdmin(static::$currentIndex.'&id_order='.$paymentModule->currentOrder.'&vieworder'.'&token='.$this->token);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Closes: https://github.com/thirtybees/thirtybees/issues/1100

Motivation

Back-office users must be able to start the order creation flow from any cart (including visitor/guest carts) and then select or create a customer on the order page instead of retyping the cart.

The previous logic prevented opening the order-create form for carts without id_customer and hid the "Create an order from this cart." action for guest carts.

Description

Show the "Create an order from this cart." button for all carts by removing the template condition in admin-dev/themes/default/template/controllers/carts/helpers/view/view.tpl so guest/visitor carts expose the action.

Remove the early renderForm() validation in controllers/admin/AdminOrdersController.php that rejected carts with no id_customer, allowing the order form to load and let the user pick or create a customer there.

Add a submit-time guard in AdminOrdersController::postProcess (the submitAddOrder branch) to require a selected customer before finalizing the order, returning the error You must select a customer before creating the order. if none is present.