### PR TITLE
Replicate delivery slip ordering in AdminOrders

### DIFF
--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -3322,7 +3322,17 @@ class AdminOrdersControllerCore extends AdminController
             }
         }
 
-        ksort($products);
+        uasort($products, static function (array $a, array $b) {
+            $nameA = trim((string)($a['product_name'] ?? ''));
+            $nameB = trim((string)($b['product_name'] ?? ''));
+
+            $cmp = strcasecmp($nameA, $nameB);
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+
+            return ((int)($a['id_order_detail'] ?? 0)) <=> ((int)($b['id_order_detail'] ?? 0));
+        });
 
         return $products;
     }


### PR DESCRIPTION
1. Same order as delivery slip.
2. Better picking for merchants not using delivery slips - up until now the order was based on the customer cart.

Now if we have same product added in position 1 and 9 for example, it will be grouped in the list for (hopefully) easier picking in the warehouse where they are (hopefully) next to next/close to each other (similar to the delivery slip logic).