### PR TITLE
Introduces Cheapest product in cart rule

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -127,6 +127,12 @@
 			</label>
 		</p>
 		<p class="radio">
+			<label for="apply_discount_to_cart_cheapest">
+				<input type="radio" name="apply_discount_to" id="apply_discount_to_cart_cheapest" value="cart_cheapest"{if $reductionProduct === CartRule::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART} checked="checked"{/if} />
+				{l s='Cheapest product in cart'}
+			</label>
+		</p>
+		<p class="radio">
 			<label for="apply_discount_to_selection">
 				<input type="radio" name="apply_discount_to" id="apply_discount_to_selection" value="selection"{if $reductionProduct === CartRule::APPLY_DISCOUNT_TO_SELECTED_PRODUCTS} checked="checked"{/if} {if $product_rule_groups|@count == 0}disabled="disabled"{/if} />
 				{l s='Selected product(s)'}
@@ -136,6 +142,20 @@
 				</span>
 			</label>
 		</p>
+	</div>
+</div>
+
+<div id="apply_discount_to_cart_cheapest_quantity_div" class="form-group">
+	<label class="control-label col-lg-3">
+		<span class="label-tooltip" data-toggle="tooltip" title="{l s='Minimum total product quantity required in the cart before the cheapest product gets the percentage discount.'}">
+			{l s='Minimum cart quantity'}
+		</span>
+	</label>
+	<div class="col-lg-9">
+		<div class="input-group col-lg-2">
+			<input type="text" id="reduction_cart_quantity" name="reduction_cart_quantity" value="{if $currentTab->getFieldValue($currentObject, 'reduction_cart_quantity')|intval > 0}{$currentTab->getFieldValue($currentObject, 'reduction_cart_quantity')|intval}{else}1{/if}" />
+		</div>
+		<span class="help-block">{l s='Example: set 3 to create a "buy 3 items, get the cheapest one discounted" rule.'}</span>
 	</div>
 </div>
 

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -151,6 +151,8 @@ function toggleApplyDiscount(percent, amount, apply_to)
 			toggleApplyDiscountTo();
 		$('#apply_discount_to_cheapest').show();
 		$('*[for=apply_discount_to_cheapest]').show();
+		$('#apply_discount_to_cart_cheapest').show();
+		$('*[for=apply_discount_to_cart_cheapest]').show();
 		$('#apply_discount_to_selection').show();
 		$('*[for=apply_discount_to_selection]').show();
 	}
@@ -168,10 +170,19 @@ function toggleApplyDiscount(percent, amount, apply_to)
 			toggleApplyDiscountTo();
 		$('#apply_discount_to_cheapest').hide();
 		$('*[for=apply_discount_to_cheapest]').hide();
-		$('#apply_discount_to_cheapest').prop('checked', false);
+		$('#apply_discount_to_cart_cheapest').hide();
+		$('*[for=apply_discount_to_cart_cheapest]').hide();
 		$('#apply_discount_to_selection').hide();
 		$('*[for=apply_discount_to_selection]').hide();
+		if ($('#apply_discount_to_cheapest').prop('checked')
+			|| $('#apply_discount_to_selection').prop('checked')
+			|| $('#apply_discount_to_cart_cheapest').prop('checked')) {
+			$('#apply_discount_to_order').prop('checked', true);
+		}
+		$('#apply_discount_to_cheapest').prop('checked', false);
 		$('#apply_discount_to_selection').prop('checked', false);
+		$('#apply_discount_to_cart_cheapest').prop('checked', false);
+		toggleApplyDiscountTo();
 	}
 	else
 	{
@@ -196,6 +207,11 @@ function toggleApplyDiscount(percent, amount, apply_to)
 
 function toggleApplyDiscountTo()
 {
+	if ($('#apply_discount_to_cart_cheapest').prop('checked'))
+		$('#apply_discount_to_cart_cheapest_quantity_div').show(400);
+	else
+		$('#apply_discount_to_cart_cheapest_quantity_div').hide(200);
+
 	if ($('#apply_discount_to_product').prop('checked'))
 		$('#apply_discount_to_product_div').show(400);
 	else
@@ -207,6 +223,9 @@ function toggleApplyDiscountTo()
 		}
 		if ($('#apply_discount_to_cheapest').prop('checked')) {
 			$('#reduction_product').val(APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_FROM_SELECTION);
+		}
+		if ($('#apply_discount_to_cart_cheapest').prop('checked')) {
+			$('#reduction_product').val(APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART);
 		}
 		if ($('#apply_discount_to_selection').prop('checked')) {
 			$('#reduction_product').val(APPLY_DISCOUNT_TO_SELECTED_PRODUCTS);
@@ -260,6 +279,12 @@ $('#apply_discount_to_cheapest').click(function(){
 	toggleApplyDiscountTo();}
 );
 if ($('#apply_discount_to_cheapest').prop('checked'))
+	toggleApplyDiscountTo();
+
+$('#apply_discount_to_cart_cheapest').click(function(){
+	toggleApplyDiscountTo();}
+);
+if ($('#apply_discount_to_cart_cheapest').prop('checked'))
 	toggleApplyDiscountTo();
 
 $('#apply_discount_to_selection').click(function(){

--- a/admin-dev/themes/default/template/controllers/cart_rules/system_rule.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/system_rule.tpl
@@ -1,0 +1,96 @@
+<div class="panel">
+	<h3><i class="icon-info-circle"></i> {l s='System cart rule'}</h3>
+	<div class="alert alert-info">
+		{l s='This cart rule was generated automatically by the system for a cheapest-product discount and is read-only.'}
+	</div>
+
+	<div class="form-horizontal">
+		<div class="row">
+			<div class="col-lg-6">
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Generated from cart rule'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">
+							{if $systemRuleDetails.source_rule_link}
+								<a href="{$systemRuleDetails.source_rule_link|escape:'html':'UTF-8'}">{$systemRuleDetails.source_rule_label|escape:'html':'UTF-8'}</a>
+							{else}
+								{$systemRuleDetails.source_rule_label|escape:'html':'UTF-8'}
+							{/if}
+						</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Created for order'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">
+							{if $systemRuleDetails.order_link}
+								<a href="{$systemRuleDetails.order_link|escape:'html':'UTF-8'}">{$systemRuleDetails.order_label|escape:'html':'UTF-8'}</a>
+							{else}
+								{$systemRuleDetails.order_label|escape:'html':'UTF-8'}
+							{/if}
+						</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Discount applied to product'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">
+							{if $systemRuleDetails.product_link}
+								<a href="{$systemRuleDetails.product_link|escape:'html':'UTF-8'}">{$systemRuleDetails.product_label|escape:'html':'UTF-8'}</a>
+							{else}
+								{$systemRuleDetails.product_label|escape:'html':'UTF-8'}
+							{/if}
+						</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Combination'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">
+							{if $systemRuleDetails.combination_label}
+								{$systemRuleDetails.combination_label|escape:'html':'UTF-8'}
+							{else}
+								{l s='No combination'}
+							{/if}
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div class="col-lg-6">
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='System generated cart rule'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">{$currentObject->code|escape:'html':'UTF-8'}</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Discount percent'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">{$systemRuleDetails.discount_percent_label|escape:'html':'UTF-8'}</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Total discount'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">{$systemRuleDetails.discount_amount_label|escape:'html':'UTF-8'}</p>
+					</div>
+				</div>
+
+				<div class="form-group">
+					<label class="control-label col-lg-5">{l s='Created at'}</label>
+					<div class="col-lg-7">
+						<p class="form-control-static">{$systemRuleDetails.created_at|escape:'html':'UTF-8'}</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+{include file="footer_toolbar.tpl"}

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -46,6 +46,7 @@ class CartRuleCore extends ObjectModel
     const APPLY_DISCOUNT_TO_ORDER_WITHOUT_SHIPPING = 0;
     const APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_FROM_SELECTION = -1;
     const APPLY_DISCOUNT_TO_SELECTED_PRODUCTS = -2;
+    const APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART = -3;
 
     const SYSTEM_RULE_CHEAPEST_PRODUCT = 'cheapest_product';
 
@@ -212,6 +213,11 @@ class CartRuleCore extends ObjectModel
     public $reduction_product;
 
     /**
+     * @var int $reduction_cart_quantity
+     */
+    public $reduction_cart_quantity;
+
+    /**
      * @var int $gift_product
      */
     public $gift_product;
@@ -278,6 +284,7 @@ class CartRuleCore extends ObjectModel
             'reduction_tax'           => ['type' => self::TYPE_BOOL,   'validate' => 'isBool', 'dbDefault' => '0'],
             'reduction_currency'      => ['type' => self::TYPE_INT,    'validate' => 'isUnsignedId', 'dbDefault' => '0'],
             'reduction_product'       => ['type' => self::TYPE_INT,    'validate' => 'isInt', 'size' => 10, 'signed' => true, 'dbDefault' => '0'],
+            'reduction_cart_quantity' => ['type' => self::TYPE_INT,    'validate' => 'isUnsignedInt', 'size' => 10, 'dbDefault' => '0'],
             'gift_product'            => ['type' => self::TYPE_INT,    'validate' => 'isUnsignedId', 'dbDefault' => '0'],
             'gift_product_attribute'  => ['type' => self::TYPE_INT,    'validate' => 'isUnsignedId', 'dbDefault' => '0'],
             'highlight'               => ['type' => self::TYPE_BOOL,   'validate' => 'isBool', 'dbDefault' => '0'],
@@ -1167,6 +1174,15 @@ class CartRuleCore extends ObjectModel
             }
         }
 
+        if ($this->reduction_percent && $this->applyDiscountToCheapestProductInCart()) {
+            $requiredQuantity = $this->getReductionCartQuantity();
+            if ($this->getCartProductsQuantity($context) < $requiredQuantity) {
+                return (!$displayError)
+                    ? false
+                    : sprintf(Tools::displayError('You need at least %d product(s) in your cart to use this voucher'), $requiredQuantity);
+            }
+        }
+
         // Check if the cart rule is only usable by a specific customer, and if the current customer is the right one
         if ($this->id_customer && $context->cart->id_customer != $this->id_customer) {
             if (!Context::getContext()->customer->isLogged()) {
@@ -1550,34 +1566,35 @@ class CartRuleCore extends ObjectModel
 
             // Discount (%) on the cheapest product
             if ($this->reduction_percent && $this->applyDiscountToCheapestProductFromSelection()) {
-                $minPrice = false;
-                $cheapestProduct = null;
                 $selectedProducts = $this->checkProductRestrictions($context, true);
                 if (is_array($selectedProducts)) {
-
-                    // find the cheapest product price
-                    foreach ($allProducts as $product) {
-                        $productKey = (int)$product['id_product'] . '-' . (int)$product['id_product_attribute'];
-                        if (in_array($productKey, $selectedProducts)) {
-                            $price = $useTax
-                                ? (float)$product['price_wt']
-                                : (float)$product['price'];
-
-                            if ($price > 0 && ($minPrice === false || $minPrice > $price)) {
-                                $minPrice = $price;
-                                $cheapestProduct = $productKey;
+                    $cheapestProduct = $this->findCheapestDiscountProduct($allProducts, $selectedProducts, $context);
+                    if ($cheapestProduct) {
+                        $cheapestProductKey = $this->getDiscountProductKey($cheapestProduct);
+                        foreach ($packageProducts as $product) {
+                            if ($this->getDiscountProductKey($product) === $cheapestProductKey) {
+                                $price = $this->getDiscountProductUnitPrice($product, $useTax, $context);
+                                $reductionValue += Tools::roundPrice($price * $this->reduction_percent / 100);
+                                break;
                             }
                         }
                     }
+                }
+            }
 
-                    // Check if the cheapest product is in the package
-                    if ($cheapestProduct) {
-                        foreach ($packageProducts as $product) {
-                            $productKey = (int)$product['id_product'] . '-' . (int)$product['id_product_attribute'];
-                            if ($productKey === $cheapestProduct) {
-                                $reductionValue += Tools::roundPrice($minPrice * $this->reduction_percent / 100);
-                                break;
-                            }
+            // Discount (%) on the cheapest product in cart
+            if ($this->reduction_percent
+                && $this->applyDiscountToCheapestProductInCart()
+                && $this->getCartProductsQuantity($context, $allProducts) >= $this->getReductionCartQuantity()
+            ) {
+                $cheapestProduct = $this->findCheapestDiscountProduct($allProducts, null, $context);
+                if ($cheapestProduct) {
+                    $cheapestProductKey = $this->getDiscountProductKey($cheapestProduct);
+                    foreach ($packageProducts as $product) {
+                        if ($this->getDiscountProductKey($product) === $cheapestProductKey) {
+                            $price = $this->getDiscountProductUnitPrice($product, $useTax, $context);
+                            $reductionValue += Tools::roundPrice($price * $this->reduction_percent / 100);
+                            break;
                         }
                     }
                 }
@@ -1887,28 +1904,101 @@ class CartRuleCore extends ObjectModel
     public function findCheapestProduct($package)
     {
         $context = Context::getContext();
-        $cheapestProduct = null;
         $allProducts = $package['products'];
 
-        if ($this->reduction_percent && $this->applyDiscountToCheapestProductFromSelection()) {
-            $minPrice = false;
-            $selectedProducts = $this->checkProductRestrictions($context, true);
-            foreach ($allProducts as $product) {
-                if (!is_array($selectedProducts) ||
-                    (!in_array($product['id_product'].'-'.$product['id_product_attribute'], $selectedProducts) && !in_array($product['id_product'].'-0', $selectedProducts))
-                ) {
-                    continue;
-                }
+        if ($this->reduction_percent && ($this->applyDiscountToCheapestProductFromSelection() || $this->applyDiscountToCheapestProductInCart())) {
+            if ($this->applyDiscountToCheapestProductInCart() && $this->getCartProductsQuantity($context) < $this->getReductionCartQuantity()) {
+                return null;
+            }
 
-                $price = $product['price'];
-                if ($price > 0 && ($minPrice === false || $minPrice > $price)) {
-                    $minPrice = $price;
-                    $cheapestProduct = $product['id_product'].'-'.$product['id_product_attribute'];
+            $selectedProducts = null;
+            if ($this->applyDiscountToCheapestProductFromSelection()) {
+                $selectedProducts = $this->checkProductRestrictions($context, true);
+                if (!is_array($selectedProducts)) {
+                    return null;
                 }
+            }
+            $cheapestProduct = $this->findCheapestDiscountProduct($allProducts, $selectedProducts, $context);
+            if ($cheapestProduct) {
+                return $this->getDiscountProductKey($cheapestProduct);
             }
         }
 
-        return $cheapestProduct;
+        return null;
+    }
+
+    /**
+     * @param Context|null $context
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public static function getCheapestProductInCartNotifications(?Context $context = null): array
+    {
+        if (!$context) {
+            $context = Context::getContext();
+        }
+        if (!Validate::isLoadedObject($context->cart)) {
+            return [];
+        }
+
+        $products = $context->cart->getProducts();
+        if (!count($products)) {
+            return [];
+        }
+
+        $indexedProducts = [];
+        foreach ($products as $product) {
+            $productKey = (int)$product['id_product'].'-'.(int)$product['id_product_attribute'];
+            if (!isset($indexedProducts[$productKey])) {
+                $indexedProducts[$productKey] = $product;
+            }
+        }
+
+        $notifications = [];
+        $package = ['products' => $products];
+        foreach ($context->cart->getCartRules() as $cartRuleData) {
+            if (!isset($cartRuleData['obj']) || !($cartRuleData['obj'] instanceof CartRule)) {
+                continue;
+            }
+
+            /** @var CartRule $cartRule */
+            $cartRule = $cartRuleData['obj'];
+            if (!$cartRule->reduction_percent
+                || !$cartRule->applyDiscountToCheapestProductInCart()
+                || (float)$cartRuleData['value_real'] <= 0
+            ) {
+                continue;
+            }
+
+            $cheapestProductKey = $cartRule->findCheapestProduct($package);
+            if (!$cheapestProductKey || !isset($indexedProducts[$cheapestProductKey])) {
+                continue;
+            }
+
+            $product = $indexedProducts[$cheapestProductKey];
+            if ((int)$product['cart_quantity'] <= 1) {
+                continue;
+            }
+
+            $productLabel = (string)$product['name'];
+            $productAttributes = trim((string)($product['attributes_small'] ?? $product['attributes'] ?? ''));
+            if ($productAttributes !== '') {
+                $productLabel .= ' ('.$productAttributes.')';
+            }
+
+            $notifications[] = sprintf(
+                Tools::displayError(
+                    'Voucher "%1$s" applies to only one unit of %2$s. Any additional units remain at full price.'
+                ),
+                (string)$cartRuleData['name'],
+                $productLabel
+            );
+        }
+
+        return array_values(array_unique($notifications));
     }
 
     /**
@@ -1998,6 +2088,14 @@ class CartRuleCore extends ObjectModel
     /**
      * @return bool
      */
+    public function applyDiscountToCheapestProductInCart(): bool
+    {
+        return (int)$this->reduction_product === static::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART;
+    }
+
+    /**
+     * @return bool
+     */
     public function applyDiscountToSpecificProduct(): bool
     {
         return (int)$this->reduction_product > 0;
@@ -2015,6 +2113,169 @@ class CartRuleCore extends ObjectModel
     }
 
     /**
+     * @return int
+     */
+    public function getReductionCartQuantity(): int
+    {
+        return max(1, (int)$this->reduction_cart_quantity);
+    }
+
+    /**
+     * @param Context $context
+     * @param array|null $products
+     *
+     * @return int
+     */
+    protected function getCartProductsQuantity(Context $context, ?array $products = null): int
+    {
+        if ($products === null) {
+            $products = $context->cart->getProducts();
+        }
+
+        $quantity = 0;
+        foreach ($products as $product) {
+            $quantity += (int)$product['cart_quantity'];
+        }
+
+        return $quantity;
+    }
+
+    /**
+     * Selects the product line that should receive cheapest-product discount.
+     * The cheapest line is determined by the customer-facing end price (tax included),
+     * while the actual reduction amount is still derived from the chosen line's
+     * tax-inclusive or tax-exclusive unit price depending on the caller.
+     *
+     * @param array $products
+     * @param array|null $selectedProducts
+     *
+     * @return array|null
+     */
+    protected function findCheapestDiscountProduct(array $products, ?array $selectedProducts = null, ?Context $context = null): ?array
+    {
+        $cheapestProduct = null;
+        $minPrice = false;
+
+        foreach ($products as $product) {
+            if (is_array($selectedProducts) && !$this->isDiscountProductSelected($product, $selectedProducts)) {
+                continue;
+            }
+
+            $price = $this->getDiscountProductUnitPrice($product, true, $context);
+            if ($price > 0 && ($minPrice === false || $minPrice > $price)) {
+                $minPrice = $price;
+                $cheapestProduct = $product;
+            }
+        }
+
+        return $cheapestProduct;
+    }
+
+    /**
+     * @param array $product
+     * @param array $selectedProducts
+     *
+     * @return bool
+     */
+    protected function isDiscountProductSelected(array $product, array $selectedProducts): bool
+    {
+        $productId = (int)($product['id_product'] ?? $product['product_id'] ?? 0);
+        $productAttributeId = (int)($product['id_product_attribute'] ?? $product['product_attribute_id'] ?? 0);
+        $productKey = $productId.'-'.$productAttributeId;
+
+        return in_array($productKey, $selectedProducts) || in_array($productId.'-0', $selectedProducts);
+    }
+
+    /**
+     * @param array $product
+     *
+     * @return string
+     */
+    protected function getDiscountProductKey(array $product): string
+    {
+        $productId = (int)($product['id_product'] ?? $product['product_id'] ?? 0);
+        $productAttributeId = (int)($product['id_product_attribute'] ?? $product['product_attribute_id'] ?? 0);
+
+        return $productId.'-'.$productAttributeId;
+    }
+
+    /**
+     * Returns effective unit price for the product line using the cart price calculator.
+     * This bypasses customer tax-display mode, which would otherwise force getPriceStatic()
+     * to return tax-excluded values even in tax-included comparisons.
+     *
+     * @param array $product
+     * @param bool $useTax
+     * @param Context|null $context
+     *
+     * @return float
+     */
+    protected function getDiscountProductUnitPrice(array $product, bool $useTax, ?Context $context = null): float
+    {
+        if (!$context) {
+            $context = Context::getContext();
+        }
+
+        $productId = (int)($product['id_product'] ?? $product['product_id'] ?? 0);
+        if (!$productId || !Validate::isLoadedObject($context->cart)) {
+            return $useTax
+                ? (float)($product['price_wt'] ?? $product['price'] ?? 0)
+                : (float)($product['price'] ?? 0);
+        }
+
+        $productAttributeId = (int)($product['id_product_attribute'] ?? $product['product_attribute_id'] ?? 0);
+        $quantity = max(1, (int)($product['cart_quantity'] ?? $product['product_quantity'] ?? 1));
+        $cacheId = implode('-', [
+            'discount-unit-price',
+            (int)$context->cart->id,
+            $productId,
+            $productAttributeId,
+            $quantity,
+            (int)$useTax,
+        ]);
+
+        if (Cache::isStored($cacheId)) {
+            return (float)Cache::retrieve($cacheId);
+        }
+
+        $priceCalculator = Adapter_ServiceLocator::get('Adapter_ProductPriceCalculator');
+        $addressFactory = Adapter_ServiceLocator::get('Adapter_AddressFactory');
+        $virtualContext = $context->cloneContext();
+        $virtualContext->cart = $context->cart;
+
+        $idAddress = Configuration::get('PS_TAX_ADDRESS_TYPE') === 'id_address_invoice'
+            ? (int)$context->cart->id_address_invoice
+            : (int)($product['id_address_delivery'] ?? $context->cart->id_address_delivery);
+        if (!$addressFactory->addressExists($idAddress)) {
+            $idAddress = null;
+        }
+
+        $null = null;
+        $price = (float)$priceCalculator->getProductPrice(
+            $productId,
+            $useTax,
+            $productAttributeId,
+            _TB_PRICE_DATABASE_PRECISION_,
+            null,
+            false,
+            true,
+            $quantity,
+            false,
+            (int)$context->cart->id_customer ? (int)$context->cart->id_customer : null,
+            (int)$context->cart->id,
+            $idAddress,
+            $null,
+            (bool)Configuration::get('PS_USE_ECOTAX'),
+            true,
+            $virtualContext
+        );
+
+        Cache::store($cacheId, $price);
+
+        return $price;
+    }
+
+    /**
      * Returns true, if this cart rule is a special system cart rule generated for selected cheapest
      * product during cart-to-order conversion
      *
@@ -2022,13 +2283,8 @@ class CartRuleCore extends ObjectModel
      */
     public function isCheapestProductSystemRule(): bool
     {
-        $object = json_decode((string)$this->description);
-        return (
-            is_object($object) &&
-            isset($object->type) &&
-            $object->type === static::SYSTEM_RULE_CHEAPEST_PRODUCT &&
-            isset($object->id_product)
-        );
+        $data = $this->getCheapestProductSystemRuleData();
+        return is_array($data) && isset($data['id_product']);
     }
 
     /**
@@ -2036,13 +2292,19 @@ class CartRuleCore extends ObjectModel
      *
      * @param int $productId
      * @param int $combinationId
+     * @param array $metadata
      * @return void
      */
-    public function setCheapestProductSystemRule(int $productId, int $combinationId)
+    public function setCheapestProductSystemRule(int $productId, int $combinationId, array $metadata = [])
     {
         $this->description = json_encode([
             'id_product'           => $productId,
             'id_product_attribute' => $combinationId,
+            'order_id'             => (int)($metadata['order_id'] ?? 0),
+            'order_reference'      => (string)($metadata['order_reference'] ?? ''),
+            'source_cart_rule_id'  => (int)($metadata['source_cart_rule_id'] ?? 0),
+            'source_name'          => (string)($metadata['source_name'] ?? ''),
+            'source_code'          => (string)($metadata['source_code'] ?? ''),
             'type'                 => static::SYSTEM_RULE_CHEAPEST_PRODUCT,
         ]);
     }
@@ -2054,10 +2316,77 @@ class CartRuleCore extends ObjectModel
      */
     public function getCheapestProductId(): int
     {
-        if ($this->isCheapestProductSystemRule()) {
-            $object = json_decode((string)$this->description);
-            return $object->id_product ?? 0;
+        $data = $this->getCheapestProductSystemRuleData();
+        return (int)($data['id_product'] ?? 0);
+    }
+
+    /**
+     * @return int
+     */
+    public function getCheapestProductAttributeId(): int
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (int)($data['id_product_attribute'] ?? 0);
+    }
+
+    /**
+     * @return int
+     */
+    public function getCheapestProductSystemSourceCartRuleId(): int
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (int)($data['source_cart_rule_id'] ?? 0);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheapestProductSystemSourceName(): string
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (string)($data['source_name'] ?? '');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheapestProductSystemSourceCode(): string
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (string)($data['source_code'] ?? '');
+    }
+
+    /**
+     * @return int
+     */
+    public function getCheapestProductSystemOrderId(): int
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (int)($data['order_id'] ?? 0);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheapestProductSystemOrderReference(): string
+    {
+        $data = $this->getCheapestProductSystemRuleData();
+        return (string)($data['order_reference'] ?? '');
+    }
+
+    /**
+     * @return array|null
+     */
+    protected function getCheapestProductSystemRuleData(): ?array
+    {
+        $data = json_decode((string)$this->description, true);
+        if (
+            is_array($data) &&
+            isset($data['type']) &&
+            $data['type'] === static::SYSTEM_RULE_CHEAPEST_PRODUCT
+        ) {
+            return $data;
         }
-        return 0;
+        return null;
     }
 }

--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -752,6 +752,7 @@ abstract class PaymentModuleCore extends Module
                 foreach ($cartRules as $cartRuleEntry) {
                     /** @var CartRule $cartRule */
                     $cartRule = $cartRuleEntry['obj'];
+                    $sourceCartRuleId = (int)$cartRule->id;
                     $package = ['id_carrier' => $order->id_carrier, 'id_address' => $order->id_address_delivery, 'products' => $productList];
                     $values = [
                         'tax_incl' => $cartRule->getContextualValue(true, $this->context, CartRule::FILTER_ACTION_ALL_NOCAP, $package),
@@ -849,7 +850,9 @@ abstract class PaymentModuleCore extends Module
 
                     // Copy a cart rule in case the cheapest product that meets the requirements gets a discount
                     // The copied cart rule is converted into a product specific cart rule
-                    if ($cartRule->product_restriction && $cartRule->reduction_percent && $cartRule->applyDiscountToCheapestProductFromSelection()) {
+                    if ($cartRule->reduction_percent
+                        && ($cartRule->applyDiscountToCheapestProductFromSelection() || $cartRule->applyDiscountToCheapestProductInCart())
+                    ) {
                         // Create a new voucher from the original
                         $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it
                         if ($cheapestProduct = $voucher->findCheapestProduct($package)) {
@@ -874,7 +877,17 @@ abstract class PaymentModuleCore extends Module
                             $voucher->active = 0;
                             $voucher->product_restriction = 1;
                             $voucher->reduction_product = CartRule::APPLY_DISCOUNT_TO_ORDER_WITHOUT_SHIPPING;
-                            $voucher->setCheapestProductSystemRule((int)$cheapestProduct[0], (int)$cheapestProduct[1]);
+                            $voucher->setCheapestProductSystemRule(
+                                (int)$cheapestProduct[0],
+                                (int)$cheapestProduct[1],
+                                [
+                                    'order_id' => (int)$order->id,
+                                    'order_reference' => (string)$order->reference,
+                                    'source_cart_rule_id' => $sourceCartRuleId,
+                                    'source_name' => (string)$cartRule->name,
+                                    'source_code' => (string)$cartRule->code,
+                                ]
+                            );
                             $voucher->add();
 
                             // load new cart rule in single language context
@@ -887,11 +900,11 @@ abstract class PaymentModuleCore extends Module
 
                     $order->addCartRule($cartRule->id, $cartRule->name, $values, 0, $cartRule->free_shipping);
 
-                    if ($idOrderState != Configuration::get('PS_OS_ERROR') && $idOrderState != Configuration::get('PS_OS_CANCELED') && !in_array($cartRule->id, $cartRuleUsed)) {
-                        $cartRuleUsed[] = $cartRule->id;
+                    if ($idOrderState != Configuration::get('PS_OS_ERROR') && $idOrderState != Configuration::get('PS_OS_CANCELED') && !in_array($sourceCartRuleId, $cartRuleUsed)) {
+                        $cartRuleUsed[] = $sourceCartRuleId;
 
                         // Create a new instance of Cart Rule without id_lang, in order to update its quantity
-                        $cartRuleToUpdate = new CartRule((int) $cartRule->id);
+                        $cartRuleToUpdate = new CartRule($sourceCartRuleId);
                         $cartRuleToUpdate->quantity = max(0, $cartRuleToUpdate->quantity - 1);
                         $cartRuleToUpdate->update();
                     }

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -2914,16 +2914,16 @@ class OrderCore extends ObjectModel
             }
 
             if ($cartRule->isCheapestProductSystemRule()) {
-                $cheapestProductId = $cartRule->getCheapestProductId();
-                if (! isset($cheapestProductDiscounts[$cheapestProductId])) {
-                    $cheapestProductDiscounts[$cheapestProductId] = [
+                $cheapestProductKey = $cartRule->getCheapestProductId().'-'.$cartRule->getCheapestProductAttributeId();
+                if (! isset($cheapestProductDiscounts[$cheapestProductKey])) {
+                    $cheapestProductDiscounts[$cheapestProductKey] = [
                         'tax_amount' => 0,
                         'tax_base'  => 0
                     ];
                 }
 
-                $cheapestProductDiscounts[$cheapestProductId]['tax_amount'] += (float)($orderCartRule['value'] - $orderCartRule['value_tax_excl']);
-                $cheapestProductDiscounts[$cheapestProductId]['tax_base'] += (float)($orderCartRule['value_tax_excl']);
+                $cheapestProductDiscounts[$cheapestProductKey]['tax_amount'] += (float)($orderCartRule['value'] - $orderCartRule['value_tax_excl']);
+                $cheapestProductDiscounts[$cheapestProductKey]['tax_base'] += (float)($orderCartRule['value_tax_excl']);
             }
         }
 
@@ -2955,10 +2955,11 @@ class OrderCore extends ObjectModel
             foreach ($taxCalculator->getTaxesAmount($discountedPriceTaxExcl) as $idTax => $unitAmount) {
                 $totalTaxBase = $quantity * $discountedPriceTaxExcl;
                 $totalAmount = $quantity * $unitAmount;
+                $orderDetailKey = (int)$orderDetail['product_id'].'-'.(int)$orderDetail['product_attribute_id'];
 
-                if (isset($cheapestProductDiscounts[$orderDetail['product_id']]['tax_base'])) {
-                    $totalTaxBase -= $cheapestProductDiscounts[$orderDetail['product_id']]['tax_base'];
-                    $totalAmount -= $cheapestProductDiscounts[$orderDetail['product_id']]['tax_amount'];
+                if (isset($cheapestProductDiscounts[$orderDetailKey]['tax_base'])) {
+                    $totalTaxBase -= $cheapestProductDiscounts[$orderDetailKey]['tax_base'];
+                    $totalAmount -= $cheapestProductDiscounts[$orderDetailKey]['tax_amount'];
                 }
 
                 $orderDetailTaxRows[] = [

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -175,6 +175,33 @@ class AdminCartRulesControllerCore extends AdminController
     public function postProcess()
     {
         if (Tools::isSubmit('submitAddcart_rule') || Tools::isSubmit('submitAddcart_ruleAndStay')) {
+            $discountType = Tools::getValue('apply_discount');
+            $applyDiscountTo = Tools::getValue('apply_discount_to');
+            if ($discountType !== 'percent' && in_array($applyDiscountTo, ['cheapest', 'selection', 'cart_cheapest'])) {
+                $applyDiscountTo = 'order';
+            }
+
+            switch ($applyDiscountTo) {
+                case 'cheapest':
+                    $_POST['reduction_product'] = CartRule::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_FROM_SELECTION;
+                    break;
+                case 'selection':
+                    $_POST['reduction_product'] = CartRule::APPLY_DISCOUNT_TO_SELECTED_PRODUCTS;
+                    break;
+                case 'cart_cheapest':
+                    $_POST['reduction_product'] = CartRule::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART;
+                    break;
+                case 'order':
+                    $_POST['reduction_product'] = CartRule::APPLY_DISCOUNT_TO_ORDER_WITHOUT_SHIPPING;
+                    break;
+            }
+
+            if ($discountType !== 'percent' || $applyDiscountTo !== 'cart_cheapest') {
+                $_POST['reduction_cart_quantity'] = 0;
+            } else {
+                $_POST['reduction_cart_quantity'] = Tools::getIntValue('reduction_cart_quantity');
+            }
+
             // If the reduction is associated to a specific product, then it must be part of the product restrictions
             if (Tools::getIntValue('reduction_product') && Tools::getValue('apply_discount_to') == 'specific' && Tools::getValue('apply_discount') != 'off') {
                 $reductionProduct = Tools::getIntValue('reduction_product');
@@ -253,6 +280,9 @@ class AdminCartRulesControllerCore extends AdminController
             }
             if (Tools::getIntValue('reduction_percent_max') < 0) {
                 $this->errors[] = Tools::displayError('Reduction max amount cannot be lower than zero.');
+            }
+            if ($discountType === 'percent' && $applyDiscountTo === 'cart_cheapest' && Tools::getIntValue('reduction_cart_quantity') < 1) {
+                $this->errors[] = Tools::displayError('The minimum cart quantity for cheapest-product discount must be at least 1.');
             }
             if (Tools::getValue('code') && ($sameCode = (int) CartRule::getIdByCode(Tools::getValue('code'))) && $sameCode !== Tools::getIntValue('id_cart_rule')) {
                 $this->errors[] = sprintf(Tools::displayError('This cart rule code is already used (conflict with cart rule %d)'), $sameCode);
@@ -550,18 +580,18 @@ class AdminCartRulesControllerCore extends AdminController
     public function renderForm()
     {
         $limit = 40;
-        $this->toolbar_btn['save-and-stay'] = [
-            'href' => '#',
-            'desc' => $this->l('Save and Stay'),
-        ];
 
         /** @var CartRule $currentObject */
         $currentObject = $this->loadObject(true);
 
         if ($currentObject->isCheapestProductSystemRule()) {
-            $this->errors[] = $this->l('This cart rule cannot be edited: it is managed by the system.');
-            return '';
+            return $this->renderSystemCartRuleForm($currentObject);
         }
+
+        $this->toolbar_btn['save-and-stay'] = [
+            'href' => '#',
+            'desc' => $this->l('Save and Stay'),
+        ];
 
         // All the filter are prefilled with the correct information
         $customerFilter = '';
@@ -671,6 +701,7 @@ class AdminCartRulesControllerCore extends AdminController
             'APPLY_DISCOUNT_TO_ORDER_WITHOUT_SHIPPING' => CartRule::APPLY_DISCOUNT_TO_ORDER_WITHOUT_SHIPPING,
             'APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_FROM_SELECTION' => CartRule::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_FROM_SELECTION,
             'APPLY_DISCOUNT_TO_SELECTED_PRODUCTS' => CartRule::APPLY_DISCOUNT_TO_SELECTED_PRODUCTS,
+            'APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART' => CartRule::APPLY_DISCOUNT_TO_CHEAPEST_PRODUCT_IN_CART,
         ]);
         $this->content .= $this->createTemplate('form.tpl')->fetch();
 
@@ -678,6 +709,199 @@ class AdminCartRulesControllerCore extends AdminController
         $this->addJqueryPlugin(['jscroll', 'typewatch']);
 
         return parent::renderForm();
+    }
+
+    /**
+     * @param CartRule $cartRule
+     *
+     * @return string
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     * @throws SmartyException
+     */
+    protected function renderSystemCartRuleForm(CartRule $cartRule): string
+    {
+        $this->toolbar_btn = [
+            'back' => [
+                'href' => static::$currentIndex.'&token='.$this->token,
+                'desc' => $this->l('Back to list'),
+            ],
+        ];
+
+        $systemRuleDetails = $this->getSystemCartRuleDetails($cartRule);
+
+        $this->context->smarty->assign(
+            [
+                'show_toolbar' => true,
+                'toolbar_btn' => $this->toolbar_btn,
+                'toolbar_scroll' => $this->toolbar_scroll,
+                'title' => [$this->l('Payment: '), $this->l('Cart Rules')],
+                'currentObject' => $cartRule,
+                'systemRuleDetails' => $systemRuleDetails,
+            ]
+        );
+
+        return $this->createTemplate('system_rule.tpl')->fetch();
+    }
+
+    /**
+     * @param CartRule $cartRule
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    protected function getSystemCartRuleDetails(CartRule $cartRule): array
+    {
+        $sourceRuleId = $cartRule->getCheapestProductSystemSourceCartRuleId();
+        $sourceRuleName = trim($cartRule->getCheapestProductSystemSourceName());
+        $sourceRuleCode = trim($cartRule->getCheapestProductSystemSourceCode());
+        $sourceRuleLink = '';
+        if ($sourceRuleId) {
+            $sourceRule = new CartRule($sourceRuleId, (int)$this->context->language->id);
+            if (Validate::isLoadedObject($sourceRule)) {
+                $sourceRuleName = (string)$sourceRule->name;
+                $sourceRuleCode = (string)$sourceRule->code;
+                $sourceRuleLink = $this->context->link->getAdminLink('AdminCartRules').'&id_cart_rule='.$sourceRuleId.'&updatecart_rule';
+            }
+        }
+
+        $orderId = $cartRule->getCheapestProductSystemOrderId();
+        $orderReference = trim($cartRule->getCheapestProductSystemOrderReference());
+        $orderLink = '';
+        $orderCurrency = null;
+        if ($orderId) {
+            $order = new Order($orderId);
+            if (Validate::isLoadedObject($order)) {
+                $orderReference = (string)$order->reference;
+                $orderLink = $this->context->link->getAdminLink('AdminOrders').'&id_order='.$orderId.'&vieworder';
+                $orderCurrency = new Currency((int)$order->id_currency);
+            }
+        }
+
+        $productId = $cartRule->getCheapestProductId();
+        $productAttributeId = $cartRule->getCheapestProductAttributeId();
+        $productLabel = (string)$productId;
+        $productLink = '';
+        $combinationLabel = '';
+        if ($productId) {
+            $product = new Product($productId, false, (int)$this->context->language->id);
+            if (Validate::isLoadedObject($product)) {
+                $productLabel = $product->name;
+                if (!empty($product->reference)) {
+                    $productLabel = $product->reference.' - '.$productLabel;
+                }
+                $productLink = $this->context->link->getAdminLink('AdminProducts').'&updateproduct&id_product='.(int)$productId;
+
+                if ($productAttributeId) {
+                    $attributeParts = [];
+                    foreach ($product->getAttributeCombinationsById($productAttributeId, (int)$this->context->language->id) as $combination) {
+                        if (!empty($combination['group_name']) && !empty($combination['attribute_name'])) {
+                            $attributeParts[] = $combination['group_name'].': '.$combination['attribute_name'];
+                        }
+                    }
+                    if ($attributeParts) {
+                        $combinationLabel = implode(', ', $attributeParts);
+                    } else {
+                        $combinationLabel = (string)$productAttributeId;
+                    }
+                }
+            }
+        }
+
+        $sourceRuleLabel = $sourceRuleName ?: $this->l('Unknown cart rule');
+        if ($sourceRuleId) {
+            $sourceRuleLabel .= ' (#'.$sourceRuleId.')';
+        }
+        if ($sourceRuleCode !== '') {
+            $sourceRuleLabel .= ' ['.$sourceRuleCode.']';
+        }
+
+        $orderLabel = $orderReference ?: $this->l('Unknown order');
+        if ($orderId) {
+            $orderLabel .= ' (#'.$orderId.')';
+        }
+
+        $discountPercent = (float)$cartRule->reduction_percent;
+        $discountPercentLabel = rtrim(rtrim(number_format($discountPercent, 2, '.', ''), '0'), '.').'%';
+        $discountAmountLabel = $this->l('Unknown');
+        if (isset($order) && Validate::isLoadedObject($order)) {
+            foreach ($order->getOrderDetailList() as $orderDetail) {
+                if ((int)$orderDetail['product_id'] !== $productId) {
+                    continue;
+                }
+                if ((int)$orderDetail['product_attribute_id'] !== $productAttributeId) {
+                    continue;
+                }
+
+                $discountAmountTaxExcl = Tools::roundPrice((float)$orderDetail['unit_price_tax_excl'] * $discountPercent / 100);
+                $discountAmountTaxIncl = Tools::roundPrice((float)$orderDetail['unit_price_tax_incl'] * $discountPercent / 100);
+                $discountAmountLabel = Tools::displayPrice($discountAmountTaxExcl, $orderCurrency);
+                if (abs($discountAmountTaxIncl - $discountAmountTaxExcl) > 0.000001) {
+                    $discountAmountLabel .= ' '.$this->l('(tax excl.)').' / '.Tools::displayPrice($discountAmountTaxIncl, $orderCurrency).' '.$this->l('(tax incl.)');
+                }
+                break;
+            }
+        }
+
+        return [
+            'back_link' => static::$currentIndex.'&token='.$this->token,
+            'source_rule_label' => $sourceRuleLabel,
+            'source_rule_link' => $sourceRuleLink,
+            'order_label' => $orderLabel,
+            'order_link' => $orderLink,
+            'product_label' => $productLabel,
+            'product_link' => $productLink,
+            'combination_label' => $combinationLabel,
+            'discount_percent_label' => $discountPercentLabel,
+            'discount_amount_label' => $discountAmountLabel,
+            'created_at' => $cartRule->date_add,
+        ];
+    }
+
+    /**
+     * @param string|null $token
+     * @param int $id
+     * @param string|null $name
+     *
+     * @return string
+     *
+     * @throws PrestaShopException
+     * @throws SmartyException
+     */
+    public function displayEditLink($token, $id, $name = null)
+    {
+        $cartRule = new CartRule((int)$id);
+        if ($cartRule->isCheapestProductSystemRule()) {
+            $tpl = $this->createTemplate('helpers/list/list_action_view.tpl');
+            $tpl->assign(
+                [
+                    'href' => $this->context->link->getAdminLink('AdminCartRules')
+                        .'&'.$this->identifier.'='.(int)$id
+                        .'&update'.$this->table
+                        .($this->page && $this->page > 1 ? '&page='.(int)$this->page : ''),
+                    'action' => $this->l('View'),
+                ]
+            );
+
+            return $tpl->fetch();
+        }
+
+        $tpl = $this->createTemplate('helpers/list/list_action_edit.tpl');
+        $tpl->assign(
+            [
+                'href' => $this->context->link->getAdminLink('AdminCartRules')
+                    .'&'.$this->identifier.'='.(int)$id
+                    .'&update'.$this->table
+                    .($this->page && $this->page > 1 ? '&page='.(int)$this->page : ''),
+                'action' => $this->l('Edit'),
+                'id' => (int)$id,
+            ]
+        );
+
+        return $tpl->fetch();
     }
 
     /**

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -445,6 +445,7 @@ class CartControllerCore extends FrontController
     {
         $this->setTemplate(_PS_THEME_DIR_.'errors.tpl');
         if (!$this->ajax) {
+            $this->context->smarty->assign('successes', CartRule::getCheapestProductInCartNotifications($this->context));
             parent::initContent();
         }
     }
@@ -472,6 +473,7 @@ class CartControllerCore extends FrontController
         if (Tools::getIsset('summary')) {
             $result = [];
             $result['summary'] = $this->context->cart->getSummaryDetails(null, true);
+            $result['successes'] = CartRule::getCheapestProductInCartNotifications($this->context);
             $result['customizedDatas'] = Product::getAllCustomizedDatas($this->context->cart->id, null, true);
             $result['HOOK_SHOPPING_CART'] = Hook::displayHook('displayShoppingCartFooter', $result['summary']);
             $result['HOOK_SHOPPING_CART_EXTRA'] = Hook::displayHook('displayShoppingCart', $result['summary']);

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -377,6 +377,7 @@ class ParentOrderControllerCore extends FrontController
     {
         $summary = $this->context->cart->getSummaryDetails();
         $this->errors = array_merge($this->errors, $summary['errors']);
+        $this->context->smarty->assign('successes', CartRule::getCheapestProductInCartNotifications($this->context));
 
         $customizedDatas = Product::getAllCustomizedDatas($this->context->cart->id);
 

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE `PREFIX_access` (
   PRIMARY KEY (`id_profile`,`id_tab`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+
 CREATE TABLE `PREFIX_accessory` (
   `id_product_1` int(11) unsigned NOT NULL,
   `id_product_2` int(11) unsigned NOT NULL,
@@ -294,6 +295,7 @@ CREATE TABLE `PREFIX_cart_rule` (
   `reduction_tax` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `reduction_currency` int(11) unsigned NOT NULL DEFAULT '0',
   `reduction_product` int(10) NOT NULL DEFAULT '0',
+  `reduction_cart_quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `gift_product` int(11) unsigned NOT NULL DEFAULT '0',
   `gift_product_attribute` int(11) unsigned NOT NULL DEFAULT '0',
   `highlight` tinyint(1) unsigned NOT NULL DEFAULT '0',
@@ -2865,4 +2867,3 @@ CREATE TABLE `PREFIX_zone_shop` (
   PRIMARY KEY (`id_zone`,`id_shop`),
   KEY `id_shop` (`id_shop`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-


### PR DESCRIPTION
- Introduces Cheapest product in cart rule.
- Introduces a read-only template for the system generated cart rules.
- Fixes bug with quantities not lowered for Cheapest in selection and cheapest in cart rules - closes https://github.com/thirtybees/thirtybees/issues/2105

- Should make modifications to errors.tpl and cart-summary.js so we can display user friendly message when we discount product from cart with only one row and quantity>1.