### PR TITLE
Fix namespace hooks

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -439,6 +439,9 @@ class HookCore extends ObjectModel
             $disableNonNativeModules = (bool) Configuration::get('PS_DISABLE_NON_NATIVE_MODULE');
         }
 
+        //Allow namespaced objects to execute Hooks thirtybees\core will become thirtybees_core and can be defined as method
+        $hookName = str_replace('\\', '_', $hookName);
+
         // Check arguments validity
         if (($idModule && !is_numeric($idModule)) || !Validate::isHookName($hookName)) {
             throw new PrestaShopException('Invalid id_module or hook_name');

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -440,7 +440,7 @@ class HookCore extends ObjectModel
         }
 
         //Allow namespaced objects to execute Hooks thirtybees\core will become thirtybees_core and can be defined as method
-        $hookName = str_replace('\\', '_', $hookName);
+		$hookName = Tools::toCamelCase($hookName);
 
         // Check arguments validity
         if (($idModule && !is_numeric($idModule)) || !Validate::isHookName($hookName)) {


### PR DESCRIPTION
ObjecModel will call hooks like

Hook::exec('actionObject'.get_class($this).'AddAfter', array('object' => $this));

Making it uncallable method name like `actionObjectthirtybees\core\testAddAfter` Normalize it to Making it callable method name like `actionObjectthirtybees_core_testAddAfter` So it can be defined as a method