### PR TITLE
Fix few manual discount issues

### DIFF
--- a/admin-dev/themes/default/template/controllers/orders/_discount_form.tpl
+++ b/admin-dev/themes/default/template/controllers/orders/_discount_form.tpl
@@ -64,6 +64,17 @@
 		</div>
 	</div>
 
+	<div id="discount_shipping_field" class="form-group">
+		<div class="col-lg-9 col-lg-offset-3">
+			<p class="checkbox">
+				<label class="control-label" for="discount_include_shipping">
+					<input type="checkbox" name="discount_include_shipping" id="discount_include_shipping" value="1" checked="checked" />
+					{l s='Include delivery amount in percentage discount'}
+				</label>
+			</p>
+		</div>
+	</div>
+
 	{if $order->hasInvoice()}
 	<div class="form-group">
 		<label class="control-label col-lg-3">

--- a/controllers/admin/AdminOrdersController.php
+++ b/controllers/admin/AdminOrdersController.php
@@ -1502,6 +1502,15 @@ class AdminOrdersControllerCore extends AdminController
             if ($this->hasEditPermission()) {
                 $orderCartRule = new OrderCartRule(Tools::getIntValue('id_order_cart_rule'));
                 if (Validate::isLoadedObject($orderCartRule) && $orderCartRule->id_order == $order->id) {
+                    $generatedCartRule = null;
+                    if ((int) $orderCartRule->id_cart_rule) {
+                        $cartRule = new CartRule((int) $orderCartRule->id_cart_rule);
+                        if ($this->isGeneratedOrderDiscountCartRule($cartRule, $order)) {
+                            $generatedCartRule = $cartRule;
+                        }
+                    }
+
+                    $res = true;
                     if ($orderCartRule->id_order_invoice) {
                         $orderInvoice = new OrderInvoice($orderCartRule->id_order_invoice);
                         if (!Validate::isLoadedObject($orderInvoice)) {
@@ -1516,7 +1525,7 @@ class AdminOrdersControllerCore extends AdminController
                         $orderInvoice->total_paid_tax_incl += $orderCartRule->value;
 
                         // Update Order Invoice
-                        $orderInvoice->update();
+                        $res = $orderInvoice->update() && $res;
                     }
 
                     // Update amounts of order
@@ -1529,9 +1538,18 @@ class AdminOrdersControllerCore extends AdminController
                     $order->total_paid_tax_excl += $orderCartRule->value_tax_excl;
 
                     // Delete Order Cart Rule and update Order
-                    $orderCartRule->delete();
-                    $order->update();
-                    Tools::redirectAdmin(static::$currentIndex.'&id_order='.$order->id.'&vieworder&conf=4&token='.$this->token);
+                    $res = $orderCartRule->delete() && $res;
+                    $res = $order->update() && $res;
+
+                    if ($res && $generatedCartRule && ! $this->isCartRuleUsedInAnyOrder((int) $generatedCartRule->id)) {
+                        $generatedCartRule->delete();
+                    }
+
+                    if ($res) {
+                        Tools::redirectAdmin(static::$currentIndex.'&id_order='.$order->id.'&vieworder&conf=4&token='.$this->token);
+                    } else {
+                        $this->errors[] = Tools::displayError('An error occurred during the voucher deletion.');
+                    }
                 } else {
                     $this->errors[] = Tools::displayError('You cannot edit this cart rule.');
                 }
@@ -1555,13 +1573,20 @@ class AdminOrdersControllerCore extends AdminController
 
                     $cartRules = [];
                     $discountValue = Tools::getNumberValue('discount_value');
+                    $includeShippingInDiscount = Tools::isSubmit('discount_include_shipping');
                     switch (Tools::getValue('discount_type')) {
                         // Percent type
                         case 1:
                             if ($discountValue < 100) {
                                 if (isset($orderInvoice)) {
-                                    $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::roundPrice($orderInvoice->total_paid_tax_incl * $discountValue / 100);
-                                    $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::roundPrice($orderInvoice->total_paid_tax_excl * $discountValue / 100);
+                                    $cartRules[$orderInvoice->id] = $this->calculatePercentageDiscountValues(
+                                        $orderInvoice->total_paid_tax_incl,
+                                        $orderInvoice->total_paid_tax_excl,
+                                        $orderInvoice->total_shipping_tax_incl,
+                                        $orderInvoice->total_shipping_tax_excl,
+                                        $discountValue,
+                                        $includeShippingInDiscount
+                                    );
 
                                     // Update OrderInvoice
                                     $this->applyDiscountOnInvoice($orderInvoice, $cartRules[$orderInvoice->id]['value_tax_incl'], $cartRules[$orderInvoice->id]['value_tax_excl']);
@@ -1569,15 +1594,27 @@ class AdminOrdersControllerCore extends AdminController
                                     $orderInvoicesCollection = $order->getInvoicesCollection();
                                     foreach ($orderInvoicesCollection as $orderInvoice) {
                                         /** @var OrderInvoice $orderInvoice */
-                                        $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::roundPrice($orderInvoice->total_paid_tax_incl * $discountValue / 100);
-                                        $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::roundPrice($orderInvoice->total_paid_tax_excl * $discountValue / 100);
+                                        $cartRules[$orderInvoice->id] = $this->calculatePercentageDiscountValues(
+                                            $orderInvoice->total_paid_tax_incl,
+                                            $orderInvoice->total_paid_tax_excl,
+                                            $orderInvoice->total_shipping_tax_incl,
+                                            $orderInvoice->total_shipping_tax_excl,
+                                            $discountValue,
+                                            $includeShippingInDiscount
+                                        );
 
                                         // Update OrderInvoice
                                         $this->applyDiscountOnInvoice($orderInvoice, $cartRules[$orderInvoice->id]['value_tax_incl'], $cartRules[$orderInvoice->id]['value_tax_excl']);
                                     }
                                 } else {
-                                    $cartRules[0]['value_tax_incl'] = Tools::roundPrice($order->total_paid_tax_incl * $discountValue / 100);
-                                    $cartRules[0]['value_tax_excl'] = Tools::roundPrice($order->total_paid_tax_excl * $discountValue / 100);
+                                    $cartRules[0] = $this->calculatePercentageDiscountValues(
+                                        $order->total_paid_tax_incl,
+                                        $order->total_paid_tax_excl,
+                                        $order->total_shipping_tax_incl,
+                                        $order->total_shipping_tax_excl,
+                                        $discountValue,
+                                        $includeShippingInDiscount
+                                    );
                                 }
                             } else {
                                 $this->errors[] = Tools::displayError('The discount value is invalid.');
@@ -1589,8 +1626,11 @@ class AdminOrdersControllerCore extends AdminController
                                 if ($discountValue > $orderInvoice->total_paid_tax_incl) {
                                     $this->errors[] = Tools::displayError('The discount value is greater than the order invoice total.');
                                 } else {
-                                    $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::roundPrice($discountValue);
-                                    $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::roundPrice($discountValue / (1 + $order->getTaxesAverageUsed() / 100));
+                                    $cartRules[$orderInvoice->id] = $this->calculateFixedDiscountValues(
+                                        $discountValue,
+                                        $orderInvoice->total_paid_tax_incl,
+                                        $orderInvoice->total_paid_tax_excl
+                                    );
 
                                     // Update OrderInvoice
                                     $this->applyDiscountOnInvoice($orderInvoice, $cartRules[$orderInvoice->id]['value_tax_incl'], $cartRules[$orderInvoice->id]['value_tax_excl']);
@@ -1602,8 +1642,11 @@ class AdminOrdersControllerCore extends AdminController
                                     if ($discountValue > $orderInvoice->total_paid_tax_incl) {
                                         $this->errors[] = Tools::displayError('The discount value is greater than the order invoice total.').$orderInvoice->getInvoiceNumberFormatted($this->context->language->id, (int) $order->id_shop).')';
                                     } else {
-                                        $cartRules[$orderInvoice->id]['value_tax_incl'] = Tools::roundPrice($discountValue);
-                                        $cartRules[$orderInvoice->id]['value_tax_excl'] = Tools::roundPrice($discountValue / (1 + $order->getTaxesAverageUsed() / 100));
+                                        $cartRules[$orderInvoice->id] = $this->calculateFixedDiscountValues(
+                                            $discountValue,
+                                            $orderInvoice->total_paid_tax_incl,
+                                            $orderInvoice->total_paid_tax_excl
+                                        );
 
                                         // Update OrderInvoice
                                         $this->applyDiscountOnInvoice($orderInvoice, $cartRules[$orderInvoice->id]['value_tax_incl'], $cartRules[$orderInvoice->id]['value_tax_excl']);
@@ -1613,8 +1656,11 @@ class AdminOrdersControllerCore extends AdminController
                                 if ($discountValue > $order->total_paid_tax_incl) {
                                     $this->errors[] = Tools::displayError('The discount value is greater than the order total.');
                                 } else {
-                                    $cartRules[0]['value_tax_incl'] = Tools::roundPrice($discountValue);
-                                    $cartRules[0]['value_tax_excl'] = Tools::roundPrice($discountValue / (1 + $order->getTaxesAverageUsed() / 100));
+                                    $cartRules[0] = $this->calculateFixedDiscountValues(
+                                        $discountValue,
+                                        $order->total_paid_tax_incl,
+                                        $order->total_paid_tax_excl
+                                    );
                                 }
                             }
                             break;
@@ -1653,11 +1699,15 @@ class AdminOrdersControllerCore extends AdminController
                     $res = true;
                     foreach ($cartRules as &$cartRule) {
                         $cartRuleObj = new CartRule();
+                        $cartRuleObj->code = $this->generateOrderDiscountCartRuleCode($order);
                         $cartRuleObj->date_from = date('Y-m-d H:i:s', strtotime('-1 hour', strtotime($order->date_add)));
                         $cartRuleObj->date_to = date('Y-m-d H:i:s', strtotime('+1 hour'));
+                        $cartRuleObj->id_customer = (int) $order->id_customer;
                         $cartRuleObj->name[Configuration::get('PS_LANG_DEFAULT')] = Tools::getValue('discount_name');
                         $cartRuleObj->quantity = 0;
                         $cartRuleObj->quantity_per_user = 1;
+                        $cartRuleObj->minimum_amount_currency = (int) $order->id_currency;
+                        $cartRuleObj->reduction_currency = (int) $order->id_currency;
                         if (Tools::getValue('discount_type') == 1) {
                             $cartRuleObj->reduction_percent = $discountValue;
                         } elseif (Tools::getValue('discount_type') == 2) {
@@ -1684,6 +1734,7 @@ class AdminOrdersControllerCore extends AdminController
                             $orderCartRule->name = Tools::getValue('discount_name');
                             $orderCartRule->value = $cartRule['value_tax_incl'];
                             $orderCartRule->value_tax_excl = $cartRule['value_tax_excl'];
+                            $orderCartRule->free_shipping = (int) (Tools::getValue('discount_type') == 3);
                             $res = $orderCartRule->add() && $res;
 
                             $order->total_discounts = static::ensurePositiveValue($order->total_discounts + $orderCartRule->value, 'total_discounts');
@@ -3070,6 +3121,100 @@ class AdminOrdersControllerCore extends AdminController
         $orderInvoice->total_paid_tax_incl -= $valueTaxIncl;
         $orderInvoice->total_paid_tax_excl -= $valueTaxExcl;
         $orderInvoice->update();
+    }
+
+    /**
+     * @param float $discountTaxIncl
+     * @param float $totalTaxIncl
+     * @param float $totalTaxExcl
+     *
+     * @return array<string, float>
+     */
+    protected function calculateFixedDiscountValues($discountTaxIncl, $totalTaxIncl, $totalTaxExcl)
+    {
+        $discountTaxIncl = Tools::roundPrice(Tools::parseNumber($discountTaxIncl));
+        $totalTaxIncl = Tools::parseNumber($totalTaxIncl);
+        $totalTaxExcl = Tools::parseNumber($totalTaxExcl);
+
+        if ($discountTaxIncl <= 0.0 || $totalTaxIncl <= 0.0) {
+            return [
+                'value_tax_incl' => $discountTaxIncl,
+                'value_tax_excl' => 0.0,
+            ];
+        }
+
+        return [
+            'value_tax_incl' => $discountTaxIncl,
+            'value_tax_excl' => Tools::roundPrice(min($totalTaxExcl, $discountTaxIncl * $totalTaxExcl / $totalTaxIncl)),
+        ];
+    }
+
+    /**
+     * @param float $totalTaxIncl
+     * @param float $totalTaxExcl
+     * @param float $shippingTaxIncl
+     * @param float $shippingTaxExcl
+     * @param float $discountPercent
+     * @param bool $includeShipping
+     *
+     * @return array<string, float>
+     */
+    protected function calculatePercentageDiscountValues($totalTaxIncl, $totalTaxExcl, $shippingTaxIncl, $shippingTaxExcl, $discountPercent, $includeShipping)
+    {
+        $discountBaseTaxIncl = Tools::parseNumber($totalTaxIncl);
+        $discountBaseTaxExcl = Tools::parseNumber($totalTaxExcl);
+
+        if (! $includeShipping) {
+            $discountBaseTaxIncl = max(0.0, $discountBaseTaxIncl - Tools::parseNumber($shippingTaxIncl));
+            $discountBaseTaxExcl = max(0.0, $discountBaseTaxExcl - Tools::parseNumber($shippingTaxExcl));
+        }
+
+        return [
+            'value_tax_incl' => Tools::roundPrice($discountBaseTaxIncl * $discountPercent / 100),
+            'value_tax_excl' => Tools::roundPrice($discountBaseTaxExcl * $discountPercent / 100),
+        ];
+    }
+
+    /**
+     * @param Order $order
+     *
+     * @return string
+     */
+    protected function generateOrderDiscountCartRuleCode(Order $order)
+    {
+        return CartRule::BO_ORDER_CODE_PREFIX.(int) $order->id.'_'.date('Ymd_His');
+    }
+
+    /**
+     * @param CartRule $cartRule
+     * @param Order $order
+     *
+     * @return bool
+     */
+    protected function isGeneratedOrderDiscountCartRule(CartRule $cartRule, Order $order)
+    {
+        if (!Validate::isLoadedObject($cartRule)) {
+            return false;
+        }
+
+        return strpos((string) $cartRule->code, CartRule::BO_ORDER_CODE_PREFIX) === 0
+            && (int) $cartRule->id_customer === (int) $order->id_customer
+            && ! (bool) $cartRule->active;
+    }
+
+    /**
+     * @param int $idCartRule
+     *
+     * @return bool
+     */
+    protected function isCartRuleUsedInAnyOrder($idCartRule)
+    {
+        return (bool) Db::getInstance()->getValue(
+            (new DbQuery())
+                ->select('COUNT(*)')
+                ->from('order_cart_rule')
+                ->where('`id_cart_rule` = '.(int) $idCartRule)
+        );
     }
 
     /**

--- a/js/admin/orders.js
+++ b/js/admin/orders.js
@@ -856,18 +856,21 @@ function init() {
     if (parseInt($(this).val(), 10) === 1) {
       // Percent type
       $('#discount_value_field').show();
+      $('#discount_shipping_field').show();
       $('#discount_currency_sign').hide();
       $('#discount_value_help').hide();
       $('#discount_percent_symbol').show();
     } else if (parseInt($(this).val(), 10) === 2) {
       // Amount type
       $('#discount_value_field').show();
+      $('#discount_shipping_field').hide();
       $('#discount_percent_symbol').hide();
       $('#discount_value_help').show();
       $('#discount_currency_sign').show();
     } else if (parseInt($(this).val(), 10) === 3) {
       // Free shipping
       $('#discount_value_field').hide();
+      $('#discount_shipping_field').hide();
     }
   });
 


### PR DESCRIPTION
## Summary

This PR fixes several issues in manual order discounts in `AdminOrdersController`.

## Fixed

### 1. Percentage manual discounts can now optionally exclude delivery

Previously, percentage discounts were always calculated from `total_paid_*`, which includes shipping.

This PR adds support for choosing whether the delivery amount should be included in the percentage discount calculation.

### 2. Fixed-amount manual discounts are now calculated correctly for mixed-tax orders

Closes https://github.com/thirtybees/thirtybees/issues/2111
Previously, fixed discounts converted tax-included amount to tax-excluded amount using:

```php
$discountValue / (1 + $order->getTaxesAverageUsed() / 100)
```

This used one blended average tax rate for the whole order, which produced incorrect `value_tax_excl` on orders containing products with different tax rates.

This PR now derives the tax-excluded amount proportionally from the actual order or invoice totals:

- `discount_tax_excl = discount_tax_incl * total_tax_excl / total_tax_incl`

This fixes incorrect `order_cart_rule.value_tax_excl` and `orders.total_discounts_tax_excl` on mixed-tax orders.

### 3. Generated CartRule metadata is now populated correctly

Previously, the backing `CartRule` created for manual order discounts did not set important metadata such as:

- `id_customer`
- `minimum_amount_currency`
- `reduction_currency`

As a result, non-default-currency orders could create historical `cart_rule` rows with incorrect currency metadata.

This PR now sets those fields from the order.

### 4. Generated manual discount CartRules are now identifiable

Previously, the generated `cart_rule` rows had no code, making them hard to distinguish from unrelated rules.

This PR now assigns a system-generated code like:

`BO_ORDER_52_20260402_153012`

This is used only as an internal marker for back-office generated order discount rules.

### 5. Deleting a manual order discount now also cleans up its generated CartRule

Previously, deleting a manual discount removed only the `order_cart_rule` row and left the generated `cart_rule` orphaned.

This PR now removes the generated `cart_rule` as well, when it is no longer referenced by any `order_cart_rule`.