### PR TITLE
Adding envelopeFrom support

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -35,6 +35,7 @@ use Thirtybees\Core\Mail\MailAddress;
 use Thirtybees\Core\Mail\MailAttachement;
 use Thirtybees\Core\Mail\MailTemplate;
 use Thirtybees\Core\Mail\MailTransport;
+use Thirtybees\Core\Mail\EnvelopeFromSupport;
 use Thirtybees\Core\Mail\Template\SimpleMailTemplate;
 use Thirtybees\Core\Mail\Transport\MailTransportNone;
 
@@ -133,6 +134,7 @@ class MailCore extends ObjectModel
      * @param int $idShop Shop ID
      * @param string|string[]|null $bcc Bcc recipient (email address)
      * @param string $replyTo Email address for setting the Reply-To header
+     * @param string|null $envelopeFrom Email address for setting the Return-Path (Envelope-From) header
      *
      * @return bool Whether sending was successful
      *
@@ -153,7 +155,8 @@ class MailCore extends ObjectModel
         $die = false,
         $idShop = null,
         $bcc = null,
-        $replyTo = null
+        $replyTo = null,
+        $envelopeFrom = null
     ) {
         try {
             // allow hooks to modify input parameters
@@ -173,6 +176,7 @@ class MailCore extends ObjectModel
                 'idShop' => &$idShop,
                 'bcc' => &$bcc,
                 'replyTo' => &$replyTo,
+                'envelopeFrom' => &$envelopeFrom,
             ]);
 
             // do NOT continue if any module returned false
@@ -212,6 +216,10 @@ class MailCore extends ObjectModel
             // get email transport
             $transportId = static::getSelectedTransport();
             $transport = static::getTransport($transportId);
+
+            if ($envelopeFrom && $transport instanceof EnvelopeFromSupport) {
+                $transport->setEnvelopeFrom($envelopeFrom);
+            }
 
             // send email via transport
             $success = $transport->sendMail(

--- a/classes/mail/EnvelopeFromSupport.php
+++ b/classes/mail/EnvelopeFromSupport.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright (C) 2017-2026 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @copyright 2017-2026 thirty bees
+ * @license   Open Software License (OSL 3.0)
+ */
+
+namespace Thirtybees\Core\Mail;
+
+/**
+ * Interface EnvelopeFromSupport
+ *
+ * Implement this interface in your MailTransport if it supports custom Return-Path / Envelope-From.
+ */
+interface EnvelopeFromSupport
+{
+    /**
+     * Sets the envelope from address (Return-Path)
+     *
+     * @param string $email
+     * @return void
+     */
+    public function setEnvelopeFrom(string $email);
+}


### PR DESCRIPTION
Adding this envelope from/return path value is helpful for setting up an email address like bounce@domain.com. Otherweise its pretty hard to cleanup your email list.

My idea was to introduce a new interface. It's a bit ugly, but on the other side it allows backward compatibility.