### PR TITLE
Harden store-credit code redemption for gift-card use

### DIFF
--- a/classes/StoreCredit.php
+++ b/classes/StoreCredit.php
@@ -119,6 +119,62 @@ class StoreCreditCore extends ObjectModel
     }
 
     /**
+     * Remaining (unspent) amount on this credit.
+     *
+     * @return float
+     */
+    public function getRemainingAmount(): float
+    {
+        return max(0.0, (float)$this->amount - (float)$this->amount_used);
+    }
+
+    /**
+     * Whether the credit is within its validity window. Empty bounds
+     * (normalized to null in the constructor) mean "no restriction".
+     *
+     * @return bool
+     */
+    public function isCurrentlyValid(): bool
+    {
+        $now = date('Y-m-d H:i:s');
+        if ($this->date_from && $this->date_from > $now) {
+            return false;
+        }
+        if ($this->date_to && $this->date_to < $now) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Bind this credit to a customer account. Only unowned credits (gift
+     * cards waiting to be redeemed by whoever received the code) or credits
+     * already owned by this customer can be claimed — entering a code must
+     * never move credit away from another customer's account.
+     *
+     * @param int $idCustomer
+     *
+     * @return bool true when the credit is (now) owned by $idCustomer
+     *
+     * @throws PrestaShopException
+     */
+    public function claimForCustomer(int $idCustomer): bool
+    {
+        if ($idCustomer <= 0) {
+            return false;
+        }
+        $owner = (int)$this->id_customer;
+        if ($owner === $idCustomer) {
+            return true;
+        }
+        if ($owner !== 0) {
+            return false;
+        }
+        $this->id_customer = $idCustomer;
+        return (bool)$this->update();
+    }
+
+    /**
      * @param string $code
      *
      * @return int

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -851,30 +851,4 @@ class ParentOrderControllerCore extends FrontController
         return CartRule::isFeatureActive() || StoreCredit::isFeatureActive();
     }
 
-    /**
-     * @return string
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    protected function getDisplayPaymentOptions(): string
-    {
-        $modulesList = Hook::getHookModuleExecList('actionProcessPaymentOptions');
-        if ($modulesList) {
-            $output = '';
-            $responses = Hook::getResponses('displayPayment');
-            foreach ($modulesList as $module) {
-                $moduleId = (int)$module['id_module'];
-                $newResponses = Hook::getResponse('actionProcessPaymentOptions', $moduleId, ['displayPayment' => $responses]);
-                if (is_array($newResponses)) {
-                    $responses = $newResponses;
-                }
-            }
-            if ($responses) {
-                $output = implode("\n", $responses);
-            }
-            return $output;
-        } else {
-            return Hook::displayHook('displayPayment') ;
-        }
-    }
 }

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -159,17 +159,26 @@ class ParentOrderControllerCore extends FrontController
                                 Tools::redirect('index.php?controller=order&addingCartRule=1');
                             }
                         } elseif (($storeCredit = StoreCredit::getByCode($code))) {
-                            if ($customerId) {
-                                $storeCredit->id_customer = $customerId;
-                                $storeCredit->update();
+                            if (!$customerId) {
+                                $this->errors[] = Tools::displayError('You need to sign in before you can redeem store credit vouchers');
+                            } elseif ((int)$storeCredit->id_customer && (int)$storeCredit->id_customer !== $customerId) {
+                                // Codes are bearer secrets: once a credit is bound to an
+                                // account, (re)entering its code must never move it to
+                                // another customer's account.
+                                $this->errors[] = Tools::displayError('This code has already been redeemed.');
+                            } elseif (!$storeCredit->isCurrentlyValid()) {
+                                $this->errors[] = Tools::displayError('This code is no longer valid.');
+                            } elseif ($storeCredit->getRemainingAmount() <= 0) {
+                                $this->errors[] = Tools::displayError('This code has no remaining balance.');
+                            } elseif (!$storeCredit->claimForCustomer($customerId)) {
+                                $this->errors[] = Tools::displayError('This code could not be redeemed. Please contact customer service.');
+                            } else {
                                 $cart = $this->context->cart;
                                 if (Validate::isLoadedObject($cart) && !$cart->use_store_credit) {
                                     $cart->use_store_credit = true;
                                     $cart->update();
                                 }
                                 $code = '';
-                            } else {
-                                $this->errors[] = Tools::displayError('You need to sign in before your can redeem store credit vouchers');
                             }
                         } else {
                             $this->errors[] = Tools::displayError('This voucher does not exists.');


### PR DESCRIPTION
### Commit 1 — Remove duplicated `getDisplayPaymentOptions()`

bb4549d declared the method twice in `ParentOrderControllerCore` (identical bodies) — a PHP fatal on every page using this controller. Kept the first declaration.

### Commit 2 — Harden store-credit code redemption

The current claim flow in `ParentOrderController::init()` (`submitAddDiscount`) does:

```php
$storeCredit->id_customer = $customerId;
$storeCredit->update();
```

unconditionally — anyone who knows (or guesses) a code can re-bind credit that already belongs to another customer's account, at any time, repeatedly. The validity window and remaining balance aren't checked either, producing confusing "you don't have store credit" failures later in the flow.

Changes:

- `StoreCredit::claimForCustomer(int $idCustomer): bool` — binding is only allowed for **unowned** credits (`id_customer = 0`, i.e. gift cards waiting to be redeemed by whoever received the code) or credits already owned by the claimant.
- `StoreCredit::isCurrentlyValid()` and `getRemainingAmount()` helpers.
- The checkout claim block now returns distinct errors (*already redeemed / no longer valid / no remaining balance*) before enabling `use_store_credit`; plus a typo fix in the sign-in message.

### Why — the gift-card use case

With this in place a gift-card module can issue an **unowned** credit carrying a code: the recipient claims it at checkout and core spends it **as payment** (`BOTH_WITHOUT_STORE_CREDIT`), so the VAT base of the redeeming order stays intact — exactly the EU multi-purpose-voucher treatment — with native partial use via `amount_used` and no `-2` leftover chains. The `tbvoucherproduct` module ships a feature-detected StoreCredit issue mode on its side (v0.6.0, branch `smiles/exploration`).

One observation while in the area: `store_credit` has no currency column (implicitly the shop default) — fine for single-currency shops, worth a thought for multi-currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
