### PR TITLE
Persist store-credit spending per order

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1115,10 +1115,20 @@ class CartCore extends ObjectModel
             return $orderTotalDiscount;
         }
 
-        if ($orderTotal > 0 && $this->use_store_credit && (int)$this->id_customer) {
+        // Store credits carry no currency, so they are only applied to carts
+        // in the shop default currency; a JPY cart would otherwise drain a
+        // EUR-granted balance one-to-one.
+        if ($orderTotal > 0 && $this->use_store_credit && (int)$this->id_customer
+            && (int)$this->id_currency === (int)Configuration::get('PS_CURRENCY_DEFAULT')) {
             if ($type == static::BOTH || $type == static::ONLY_STORE_CREDIT) {
                 $creditAvailable = StoreCredit::getByCustomerId((int)$this->id_shop, (int)$this->id_customer);
-                $creditUsed = Tools::roundPrice(max(0.0, min($orderTotal, $creditAvailable)));
+                // FLOOR to the display precision. The credit balance can hold
+                // sub-precision dust (6-decimal column); rounding UP would
+                // promise more than the balance covers and make the order-time
+                // debit fail deterministically. Flooring leaves the dust on
+                // the credit instead of blocking the checkout.
+                $factor = pow(10, (int) $displayPrecision);
+                $creditUsed = floor(max(0.0, min($orderTotal, $creditAvailable)) * $factor) / $factor;
                 if ($type == static::BOTH) {
                     $orderTotal -= $creditUsed;
                 } else {

--- a/classes/StoreCredit.php
+++ b/classes/StoreCredit.php
@@ -23,6 +23,11 @@
  */
 class StoreCreditCore extends ObjectModel
 {
+    /**
+     * Payment method label used for the OrderPayment row that surfaces spent
+     * store credit on the order and its documents.
+     */
+    const ORDER_PAYMENT_METHOD = 'Store credit';
 
     /**
      * @var int $id
@@ -149,7 +154,7 @@ class StoreCreditCore extends ObjectModel
     /**
      * Bind this credit to a customer account. Only unowned credits (gift
      * cards waiting to be redeemed by whoever received the code) or credits
-     * already owned by this customer can be claimed — entering a code must
+     * already owned by this customer can be claimed - entering a code must
      * never move credit away from another customer's account.
      *
      * @param int $idCustomer
@@ -218,13 +223,18 @@ class StoreCreditCore extends ObjectModel
      */
     public static function getByCustomerId(int $shopId, int $customerId): float
     {
-        $conn = Db::readOnly();
+        // Master connection on purpose: this figure decides how much money the
+        // checkout may spend, so it must not lag behind a just-booked debit on
+        // a replicated setup.
+        $conn = Db::getInstance();
         $sql = (new DbQuery())
             ->select('SUM(c.amount - c.amount_used)')
             ->from('store_credit', 'c')
             ->innerJoin('store_credit_shop', 'cs', 'c.id_store_credit = cs.id_store_credit AND cs.id_shop = ' . (int)$shopId)
             ->where('c.id_customer = ' . (int)$customerId)
             ->where('c.date_from <= NOW()')
+            // Dates before 1900 mean "no expiry": the constructor normalizes
+            // 0000-00-00 to null and empty bounds are stored as zero dates.
             ->where('(c.date_to < "1900-00-00" OR c.date_to >= NOW())');
         return (float)$conn->getValue($sql);
     }
@@ -238,6 +248,253 @@ class StoreCreditCore extends ObjectModel
     public static function isFeatureActive(): bool
     {
         return static::isCurrentlyUsed('store_credit');
+    }
+
+    /**
+     * Debit $amount from the order's customer credit balance and record one
+     * StoreCreditSpend row per credit touched. This is the durable side of
+     * paying with store credit: Cart::getOrderTotal() only lowers the payable
+     * total, and without this booking the balance would never decrease and
+     * nothing on the order would show the credit was used.
+     *
+     * Credits are consumed deterministically: soonest expiry first (credits
+     * without an expiry last), then oldest first. Each debit is a single
+     * conditional UPDATE guarded by the remaining balance, so two concurrent
+     * checkouts can never spend the same money; a lost race simply moves on
+     * to the customer's next credit.
+     *
+     * Either the full amount is booked or nothing is: on shortfall (usually a
+     * concurrent spend) all debits and spend rows of this call are rolled
+     * back and a PrestaShopException is thrown, so order validation aborts
+     * instead of leaving a half-booked payment.
+     *
+     * @param Order $order
+     * @param float $amount tax-included amount the cart covered from credit
+     *
+     * @return array rows: id_store_credit, code, amount - one per credit used
+     *
+     * @throws PrestaShopException
+     */
+    public static function spendForOrder(Order $order, float $amount): array
+    {
+        $amount = Tools::roundPrice(max(0.0, $amount));
+        if (!$amount) {
+            return [];
+        }
+        $idCustomer = (int) $order->id_customer;
+        if ($idCustomer <= 0) {
+            throw new PrestaShopException('Store credit can only be spent by a customer account.');
+        }
+
+        $conn = Db::getInstance();
+        $candidates = $conn->getArray((new DbQuery())
+            ->select('c.id_store_credit, c.code, c.amount, c.amount_used')
+            ->from('store_credit', 'c')
+            ->innerJoin('store_credit_shop', 'cs', 'c.id_store_credit = cs.id_store_credit AND cs.id_shop = ' . (int) $order->id_shop)
+            ->where('c.id_customer = ' . $idCustomer)
+            ->where('c.date_from <= NOW()')
+            // Dates before 1900 mean "no expiry", see getByCustomerId().
+            ->where('(c.date_to < "1900-00-00" OR c.date_to >= NOW())')
+            ->where('(c.amount - c.amount_used) > 0')
+            ->orderBy('IF(c.date_to < "1900-00-00", 1, 0) ASC, c.date_to ASC, c.date_add ASC, c.id_store_credit ASC')
+        );
+
+        $remaining = $amount;
+        $spends = [];
+        foreach ($candidates as $row) {
+            if (Tools::roundPrice($remaining) <= 0) {
+                break;
+            }
+            $balance = (float) $row['amount'] - (float) $row['amount_used'];
+
+            // Two attempts per credit: the first uses the balance from the
+            // candidate snapshot; when that debit loses a race against a
+            // concurrent checkout, the balance is re-read once and the debit
+            // retried with the smaller slice, so money that still exists is
+            // not skipped (skipping would over-consume later-expiring credits
+            // or abort an order the funds do cover).
+            for ($attempt = 0; $attempt < 2; $attempt++) {
+                $take = min($remaining, $balance);
+                if (Tools::roundPrice($take) <= 0) {
+                    break;
+                }
+                $takeSql = static::sqlAmount($take);
+
+                // Conditional debit: succeeds only when the balance still
+                // covers it, so a concurrent checkout can never spend the
+                // same money.
+                $debited = $conn->execute(
+                    'UPDATE `' . _DB_PREFIX_ . 'store_credit`
+                     SET amount_used = amount_used + ' . $takeSql . ', date_upd = NOW()
+                     WHERE id_store_credit = ' . (int) $row['id_store_credit'] . '
+                       AND (amount - amount_used) >= ' . $takeSql
+                );
+                if (!$debited || !$conn->Affected_Rows()) {
+                    // Lost a race; refresh the live balance and try the
+                    // remainder of this credit once before moving on.
+                    $balance = (float) $conn->getValue((new DbQuery())
+                        ->select('amount - amount_used')
+                        ->from('store_credit')
+                        ->where('id_store_credit = ' . (int) $row['id_store_credit'])
+                    );
+                    continue;
+                }
+
+                try {
+                    $spend = new StoreCreditSpend();
+                    $spend->id_store_credit = (int) $row['id_store_credit'];
+                    $spend->id_order = (int) $order->id;
+                    $spend->amount = $take;
+                    $recorded = $spend->add();
+                } catch (Throwable $e) {
+                    $recorded = false;
+                }
+                if (!$recorded) {
+                    // The debit must never exist without its record; give the
+                    // money back and stop with an error.
+                    static::revertSpends($spends, (int) $row['id_store_credit'], $takeSql);
+                    throw new PrestaShopException('Could not record the store credit spend.');
+                }
+
+                $spends[] = [
+                    'id_store_credit' => (int) $row['id_store_credit'],
+                    'id_spend' => (int) $spend->id,
+                    'code' => (string) $row['code'],
+                    'amount' => $take,
+                ];
+                $remaining -= $take;
+                break;
+            }
+        }
+
+        if (Tools::roundPrice($remaining) > 0) {
+            // Balance fell short (usually a concurrent spend between the cart
+            // total and this booking). All or nothing: undo and abort.
+            static::revertSpends($spends);
+            throw new PrestaShopException('The store credit balance no longer covers this order. Please review your cart and try again.');
+        }
+
+        return $spends;
+    }
+
+    /**
+     * Compensation for a spend that must not stand: restore the debited
+     * balances and remove the spend rows. Used by spendForOrder() itself and
+     * by PaymentModule::validateOrder() when order creation fails after the
+     * credit was already booked. Optionally also reverts one extra bare debit
+     * that has no spend row yet.
+     *
+     * Failures in here are logged loudly instead of thrown: this method runs
+     * on error paths where a second exception would mask the original one,
+     * but a debit that could not be restored must never disappear silently.
+     *
+     * @param array $spends rows as built by spendForOrder()
+     * @param int|null $extraIdCredit credit debited but not yet recorded
+     * @param string|null $extraAmountSql its amount, pre-formatted for SQL
+     *
+     * @throws PrestaShopException
+     */
+    public static function revertSpends(array $spends, ?int $extraIdCredit = null, ?string $extraAmountSql = null)
+    {
+        $conn = Db::getInstance();
+        foreach ($spends as $spend) {
+            $amountSql = static::sqlAmount((float) $spend['amount']);
+            $restored = $conn->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'store_credit`
+                 SET amount_used = GREATEST(0, amount_used - ' . $amountSql . '), date_upd = NOW()
+                 WHERE id_store_credit = ' . (int) $spend['id_store_credit']
+            );
+            if (!$restored) {
+                Logger::addLog('StoreCredit::revertSpends - could not restore ' . $amountSql . ' to credit ' . (int) $spend['id_store_credit'] . ', manual correction needed', 3);
+            }
+            if (!$conn->delete('store_credit_spend', 'id_store_credit_spend = ' . (int) $spend['id_spend'])) {
+                Logger::addLog('StoreCredit::revertSpends - could not remove spend row ' . (int) $spend['id_spend'], 3);
+            }
+        }
+        if ($extraIdCredit !== null && $extraAmountSql !== null) {
+            $restored = $conn->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'store_credit`
+                 SET amount_used = GREATEST(0, amount_used - ' . $extraAmountSql . '), date_upd = NOW()
+                 WHERE id_store_credit = ' . $extraIdCredit
+            );
+            if (!$restored) {
+                Logger::addLog('StoreCredit::revertSpends - could not restore ' . $extraAmountSql . ' to credit ' . $extraIdCredit . ', manual correction needed', 3);
+            }
+        }
+    }
+
+    /**
+     * Give the credit spent on an order back to the customer. Called when an
+     * order reaches a cancelled, payment-error or refund state, so credit
+     * spent on an order that never completes is not lost.
+     *
+     * Idempotent and race safe: each spend row is claimed by a conditional
+     * "mark reverted" UPDATE before the money moves, so a state bouncing
+     * between cancelled and error can never refund twice. Marking first means
+     * a crash between the two statements loses the refund rather than paying
+     * it double; that case is logged for manual correction (the safer of the
+     * two failure modes for the shop).
+     *
+     * @param int $idOrder
+     *
+     * @return int number of spend rows restored
+     *
+     * @throws PrestaShopException
+     */
+    public static function restoreForOrder(int $idOrder): int
+    {
+        $conn = Db::getInstance();
+        // Zero dates mean "never reverted", matching the credit validity
+        // convention (the column defaults to 0000-00-00, not NULL).
+        $notReverted = '(date_reverted IS NULL OR date_reverted < "1900-00-00")';
+        $rows = $conn->getArray((new DbQuery())
+            ->select('id_store_credit_spend, id_store_credit, amount')
+            ->from('store_credit_spend')
+            ->where('id_order = ' . (int) $idOrder)
+            ->where($notReverted)
+        );
+
+        $restored = 0;
+        foreach ($rows as $row) {
+            $claimed = $conn->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'store_credit_spend`
+                 SET date_reverted = NOW()
+                 WHERE id_store_credit_spend = ' . (int) $row['id_store_credit_spend'] . '
+                   AND ' . $notReverted
+            );
+            if (!$claimed || !$conn->Affected_Rows()) {
+                // Another process already reverted this row.
+                continue;
+            }
+
+            $amountSql = static::sqlAmount((float) $row['amount']);
+            $refunded = $conn->execute(
+                'UPDATE `' . _DB_PREFIX_ . 'store_credit`
+                 SET amount_used = GREATEST(0, amount_used - ' . $amountSql . '), date_upd = NOW()
+                 WHERE id_store_credit = ' . (int) $row['id_store_credit']
+            );
+            if (!$refunded) {
+                Logger::addLog('StoreCredit::restoreForOrder - spend row ' . (int) $row['id_store_credit_spend'] . ' marked reverted but restoring ' . $amountSql . ' to credit ' . (int) $row['id_store_credit'] . ' failed, manual correction needed', 3);
+                continue;
+            }
+            $restored++;
+        }
+
+        return $restored;
+    }
+
+    /**
+     * Format a monetary amount for direct use in SQL, at the database price
+     * precision. Shared by every raw credit UPDATE so the debit, the revert
+     * and the restore always move exactly the same figure.
+     *
+     * @param float $amount
+     *
+     * @return string
+     */
+    protected static function sqlAmount(float $amount): string
+    {
+        return number_format($amount, _TB_PRICE_DATABASE_PRECISION_, '.', '');
     }
 
 }

--- a/classes/StoreCreditSpend.php
+++ b/classes/StoreCreditSpend.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright (C) 2025-2026 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @copyright 2026 thirty bees
+ * @license   Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class StoreCreditSpendCore
+ *
+ * One row per store credit consumed by an order: the durable record of "this
+ * order was paid with this much of that credit". An order may consume several
+ * credits, and a credit may serve several orders through partial use. Written
+ * by StoreCredit::spendForOrder() during order validation; read by documents,
+ * support tooling and modules.
+ */
+class StoreCreditSpendCore extends ObjectModel
+{
+    /**
+     * @var int $id
+     */
+    public $id;
+
+    /**
+     * @var int $id_store_credit
+     */
+    public $id_store_credit;
+
+    /**
+     * @var int $id_order
+     */
+    public $id_order;
+
+    /**
+     * @var float $amount Amount taken from this credit for this order
+     */
+    public $amount;
+
+    /**
+     * @var string|null $date_reverted When set, this spend has been given back
+     *                                 to the credit (order cancelled, payment
+     *                                 error or refund) and must not be
+     *                                 reverted again.
+     */
+    public $date_reverted;
+
+    /**
+     * @var string $date_add
+     */
+    public $date_add;
+
+    /**
+     * @var array Object model definition
+     */
+    public static $definition = [
+        'table'   => 'store_credit_spend',
+        'primary' => 'id_store_credit_spend',
+        'fields'  => [
+            'id_store_credit' => ['type' => self::TYPE_INT,   'validate' => 'isUnsignedId', 'required' => true],
+            'id_order'        => ['type' => self::TYPE_INT,   'validate' => 'isUnsignedId', 'required' => true],
+            'amount'          => ['type' => self::TYPE_PRICE, 'validate' => 'isPrice'],
+            'date_reverted'   => ['type' => self::TYPE_DATE,  'validate' => 'isDate', 'dbDefault' => '0000-00-00 00:00:00'],
+            'date_add'        => ['type' => self::TYPE_DATE,  'validate' => 'isDate', 'dbNullable' => false],
+        ],
+        'keys' => [
+            'store_credit_spend' => [
+                'id_store_credit' => ['type' => ObjectModel::KEY, 'columns' => ['id_store_credit']],
+                'id_order'        => ['type' => ObjectModel::KEY, 'columns' => ['id_order']],
+            ],
+        ],
+    ];
+
+    /**
+     * @param int|null $id
+     * @param int|null $idLang
+     * @param int|null $idShop
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function __construct($id = null, $idLang = null, $idShop = null)
+    {
+        parent::__construct($id, $idLang, $idShop);
+        // Same zero-date convention as StoreCredit's validity bounds: the
+        // column stores 0000-00-00 for "never reverted", PHP sees null.
+        if ($this->date_reverted === '0000-00-00 00:00:00') {
+            $this->date_reverted = null;
+        }
+    }
+
+    /**
+     * All credit spends recorded for an order, including the credit's code
+     * and name so documents can print them without another lookup. Consumed
+     * by StoreCredit::restoreForOrder() and intended as the read API for
+     * refund tooling and modules (gift-card modules print "paid with voucher
+     * X" on documents and report redemption per period from these rows).
+     *
+     * @param int $idOrder
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    public static function getSpendsForOrder(int $idOrder): array
+    {
+        // date_reverted is normalized in SQL: the zero-date "never reverted"
+        // sentinel comes out as NULL, so callers can simply truth-test it.
+        return Db::readOnly()->getArray((new DbQuery())
+            ->select('s.id_store_credit_spend, s.id_store_credit, s.amount, s.date_add, c.code, c.name,
+                      IF(s.date_reverted IS NULL OR s.date_reverted < "1900-00-00", NULL, s.date_reverted) AS date_reverted')
+            ->from('store_credit_spend', 's')
+            ->innerJoin('store_credit', 'c', 'c.id_store_credit = s.id_store_credit')
+            ->where('s.id_order = ' . (int) $idOrder)
+            ->orderBy('s.id_store_credit_spend ASC')
+        );
+    }
+
+    /**
+     * All orders a credit was spent on, newest first. Used by the back office
+     * to answer "where did this balance go?".
+     *
+     * @param int $idStoreCredit
+     *
+     * @return array
+     *
+     * @throws PrestaShopException
+     */
+    public static function getSpendsForCredit(int $idStoreCredit): array
+    {
+        return Db::readOnly()->getArray((new DbQuery())
+            ->select('s.id_store_credit_spend, s.id_order, s.amount, s.date_add, o.reference,
+                      IF(s.date_reverted IS NULL OR s.date_reverted < "1900-00-00", NULL, s.date_reverted) AS date_reverted')
+            ->from('store_credit_spend', 's')
+            ->leftJoin('orders', 'o', 'o.id_order = s.id_order')
+            ->where('s.id_store_credit = ' . (int) $idStoreCredit)
+            ->orderBy('s.id_store_credit_spend DESC')
+        );
+    }
+}

--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -555,6 +555,26 @@ abstract class PaymentModuleCore extends Module
                     $order->total_paid_tax_excl = (float) (float) $this->context->cart->getOrderTotal(false, Cart::BOTH, $productList, $idCarrier);
                     $order->total_paid_tax_incl = (float) (float) $this->context->cart->getOrderTotal(true, Cart::BOTH, $productList, $idCarrier);
                     $order->total_paid = $order->total_paid_tax_incl;
+
+                    // Store credit: the BOTH totals above are NET (the credit
+                    // was subtracted so the gateway only charges the rest).
+                    // The ORDER must carry the GROSS totals, with the credit
+                    // recorded as a payment next to the gateway's, otherwise
+                    // the payments would sum above the order total on every
+                    // credit order. The applied amount is the per-package
+                    // with/without difference, so it mirrors exactly what the
+                    // totals deducted.
+                    $storeCreditApplied = 0.0;
+                    if ($this->context->cart->use_store_credit && (int) $this->context->cart->id_customer) {
+                        $grossTaxIncl = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH_WITHOUT_STORE_CREDIT, $productList, $idCarrier);
+                        $storeCreditApplied = Tools::roundPrice($grossTaxIncl - $order->total_paid_tax_incl);
+                        if ($storeCreditApplied > 0) {
+                            $order->total_paid_tax_excl = (float) $this->context->cart->getOrderTotal(false, Cart::BOTH_WITHOUT_STORE_CREDIT, $productList, $idCarrier);
+                            $order->total_paid_tax_incl = $grossTaxIncl;
+                            $order->total_paid = $grossTaxIncl;
+                        }
+                    }
+
                     $order->round_mode = Configuration::get('PS_PRICE_ROUND_MODE');
                     $order->round_type = (int) Configuration::get('PS_ROUND_TYPE');
 
@@ -597,7 +617,8 @@ abstract class PaymentModuleCore extends Module
                         'order' => $order,
                         'productList' => $productList,
                         'outOfStock' => $outOfStock,
-                        'carrierName' => $carrier ? $carrier->getName() : Tools::displayError('No carrier')
+                        'carrierName' => $carrier ? $carrier->getName() : Tools::displayError('No carrier'),
+                        'storeCreditApplied' => $storeCreditApplied,
                     ];
                 }
             }
@@ -612,17 +633,53 @@ abstract class PaymentModuleCore extends Module
                 throw new PrestaShopException('The order address country is not active.');
             }
 
-            // Register Payment only if the order status validate the order
-            if ($orderStatus->logable) {
-                // $order is the last order loop in the foreach
-                // The method addOrderPayment of the class Order make a create a paymentOrder
-                // linked to the order reference and not to the order id
-                $transactionId = $extraVars['transaction_id'] ?? null;
+            // Book the store credit and register the payments. Everything in
+            // this block is guarded: once credit has been debited, any later
+            // failure restores it before the exception continues, so a failed
+            // validation can never strand the customer's balance against a
+            // half-created order.
+            $storeCreditSpends = [];
+            try {
+                foreach ($orders as $orderEntry) {
+                    if (empty($orderEntry['storeCreditApplied'])) {
+                        continue;
+                    }
+                    /** @var Order $creditOrder */
+                    $creditOrder = $orderEntry['order'];
 
-                if (!isset($order) || !Validate::isLoadedObject($order) || !$order->addOrderPayment($amountPaid, null, $transactionId)) {
-                    Logger::addLog('PaymentModule::validateOrder - Cannot save Order Payment', 3, null, 'Cart', (int) $idCart, true);
-                    throw new PrestaShopException('Can\'t save Order Payment');
+                    // Debit the customer's credits (race safe, expiring
+                    // first), one spend row per credit touched, and surface
+                    // the amount as a regular order payment next to the
+                    // gateway's so the order and its documents reconcile.
+                    $spends = StoreCredit::spendForOrder($creditOrder, (float) $orderEntry['storeCreditApplied']);
+                    $storeCreditSpends = array_merge($storeCreditSpends, $spends);
+
+                    $transactionIdSize = (int) OrderPayment::$definition['fields']['transaction_id']['size'];
+                    $spentCodes = mb_substr(implode(', ', array_filter(array_column($spends, 'code'))), 0, $transactionIdSize);
+                    if (!$creditOrder->addOrderPayment((float) $orderEntry['storeCreditApplied'], StoreCredit::ORDER_PAYMENT_METHOD, $spentCodes)) {
+                        Logger::addLog('PaymentModule::validateOrder - Cannot save store-credit Order Payment', 3, null, 'Cart', (int) $idCart, true);
+                        throw new PrestaShopException('Can\'t save store credit Order Payment');
+                    }
                 }
+
+                // Register Payment only if the order status validate the order
+                if ($orderStatus->logable) {
+                    // $order is the last order loop in the foreach
+                    // The method addOrderPayment of the class Order make a create a paymentOrder
+                    // linked to the order reference and not to the order id
+                    $transactionId = $extraVars['transaction_id'] ?? null;
+
+                    if (!isset($order) || !Validate::isLoadedObject($order) || !$order->addOrderPayment($amountPaid, null, $transactionId)) {
+                        Logger::addLog('PaymentModule::validateOrder - Cannot save Order Payment', 3, null, 'Cart', (int) $idCart, true);
+                        throw new PrestaShopException('Can\'t save Order Payment');
+                    }
+                }
+            } catch (Throwable $e) {
+                if ($storeCreditSpends) {
+                    StoreCredit::revertSpends($storeCreditSpends);
+                    Logger::addLog('PaymentModule::validateOrder - order validation failed after store credit was booked; the credit has been restored', 3, null, 'Cart', (int) $idCart, true);
+                }
+                throw $e;
             }
 
             // Next !

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -119,6 +119,17 @@ class OrderHistoryCore extends ObjectModel
             'order' => $order
         ], $shopId);
 
+        // Give spent store credit back when the order lands in an error or
+        // cancelled state (the money mirror of the stock re-injection below):
+        // an order that will never complete must not keep the customer's
+        // balance. Refund states deliberately do NOT auto-restore, because how
+        // a refund is paid back is the merchant's call. restoreForOrder() is
+        // idempotent, so a state bouncing between error and cancelled can only
+        // restore once.
+        if ($newOs->isErrorOrCanceled() && (!Validate::isLoadedObject($oldOs) || !$oldOs->isErrorOrCanceled())) {
+            StoreCredit::restoreForOrder($orderId);
+        }
+
         // An email is sent the first time a virtual item is validated
         $virtualProducts = $order->getVirtualProducts();
         if (is_array($virtualProducts) && !empty($virtualProducts) && (!$oldOs || !$oldOs->logable) && $newOs->logable) {

--- a/controllers/admin/AdminStoreCreditController.php
+++ b/controllers/admin/AdminStoreCreditController.php
@@ -203,6 +203,75 @@ class AdminStoreCreditControllerCore extends AdminController
     }
 
     /**
+     * Append the read-only spend history when editing an existing credit, so
+     * support can answer "where did this balance go?" from the credit side.
+     *
+     * @return string
+     *
+     * @throws PrestaShopException
+     */
+    public function renderForm()
+    {
+        $credit = $this->loadObject(true);
+        if (Validate::isLoadedObject($credit)) {
+            $this->fields_form['input'][] = [
+                'type' => 'html',
+                'name' => 'spend_history',
+                'html_content' => $this->renderSpendHistory((int) $credit->id),
+            ];
+        }
+
+        return parent::renderForm();
+    }
+
+    /**
+     * @param int $idStoreCredit
+     *
+     * @return string
+     *
+     * @throws PrestaShopException
+     */
+    protected function renderSpendHistory(int $idStoreCredit)
+    {
+        $spends = StoreCreditSpend::getSpendsForCredit($idStoreCredit);
+
+        $html = '<div class="form-group"><label>' . $this->l('Spend history') . '</label>';
+        if (!$spends) {
+            return $html . '<div class="alert alert-info">'
+                . $this->l('This credit has not been spent on any order yet.')
+                . '</div></div>';
+        }
+
+        $currency = Currency::getCurrencyInstance((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $rows = '';
+        foreach ($spends as $spend) {
+            $orderCell = htmlspecialchars((string) $spend['reference']);
+            if ((int) $spend['id_order']) {
+                $orderUrl = $this->context->link->getAdminLink('AdminOrders')
+                    . '&id_order=' . (int) $spend['id_order'] . '&vieworder';
+                $orderCell = '<a href="' . htmlspecialchars($orderUrl) . '">' . $orderCell . '</a>';
+            }
+            $statusCell = $spend['date_reverted']
+                ? '<span class="label label-warning">' . $this->l('Reverted') . ' ' . htmlspecialchars((string) $spend['date_reverted']) . '</span>'
+                : '<span class="label label-success">' . $this->l('Spent') . '</span>';
+            $rows .= '<tr>'
+                . '<td>' . htmlspecialchars((string) $spend['date_add']) . '</td>'
+                . '<td>' . $orderCell . '</td>'
+                . '<td class="text-right">' . Tools::displayPrice((float) $spend['amount'], $currency) . '</td>'
+                . '<td>' . $statusCell . '</td>'
+                . '</tr>';
+        }
+
+        return $html
+            . '<table class="table" style="max-width:680px;"><thead><tr>'
+            . '<th>' . $this->l('Date') . '</th>'
+            . '<th>' . $this->l('Order') . '</th>'
+            . '<th class="text-right">' . $this->l('Amount') . '</th>'
+            . '<th>' . $this->l('Status') . '</th>'
+            . '</tr></thead><tbody>' . $rows . '</tbody></table></div>';
+    }
+
+    /**
      * @throws PrestaShopException
      */
     public function initToolbar()

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -136,7 +136,7 @@ class ParentOrderControllerCore extends FrontController
                         $this->errors[] = Tools::displayError('The voucher code is invalid.');
                     } else {
                         if ($customerId && ($code === static::STORE_CREDIT_CODE)) {
-                            $credit = StoreCredit::getByCustomerId($customerId, $this->context->shop->id);
+                            $credit = StoreCredit::getByCustomerId((int) $this->context->shop->id, $customerId);
                             if ($credit <= 0.0) {
                                 $this->errors[] = Tools::displayError('You don\'t have store credit.');
                             } else {
@@ -482,7 +482,7 @@ class ParentOrderControllerCore extends FrontController
 
 
         if ($customerId && !$this->context->cart->use_store_credit) {
-            $credit = StoreCredit::getByCustomerId($customerId, $this->context->shop->id);
+            $credit = StoreCredit::getByCustomerId((int) $this->context->shop->id, $customerId);
             if ($credit > 0.0) {
                 $availableCartRules[] = [
                     'id_cart_rule' => -1,

--- a/tests/Integration/WebserviceMetadataTest.php
+++ b/tests/Integration/WebserviceMetadataTest.php
@@ -86,6 +86,8 @@ class WebserviceMetadataTest extends Unit
         Risk::class,
         Scene::class,
         StockMvt::class, // exposed as StockMvtWs
+        StoreCredit::class,
+        StoreCreditSpend::class,
         Tab::class,
         Theme::class,
         UrlRewrite::class,

--- a/tests/Support/override/classes/StoreCreditSpend.php
+++ b/tests/Support/override/classes/StoreCreditSpend.php
@@ -1,0 +1,6 @@
+<?php
+
+class StoreCreditSpend extends StoreCreditSpendCore
+{
+
+}


### PR DESCRIPTION
Follow-up to #2128, verified against wip HEAD `6840511`.

## Problem

Paying with store credit only lowers the payable total in `Cart::getOrderTotal()`. Nothing is persisted at order creation:

- `amount_used` never increases, so the balance never decreases and the same credit lowers the next order again;
- no credit-to-order association exists;
- no `OrderPayment` row is written, so the order and its documents show nothing and the totals do not add up.

## Change

- **New `StoreCreditSpend` model** (`store_credit_spend`): one row per credit consumed by an order, with a `date_reverted` zero-date sentinel. Lookups by order and by credit.
- **`StoreCredit::spendForOrder()`**: debits the customer's valid credits, soonest expiry first. Each debit is a conditional `UPDATE ... WHERE (amount - amount_used) >= :take`, so concurrent checkouts cannot spend the same money; a lost race re-reads the balance and retries once. All or nothing: on shortfall every debit of the call is reverted and order validation aborts. Compensation failures are logged.
- **`PaymentModule::validateOrder()`**: orders paid (partly) with credit carry GROSS totals; the credit is surfaced as a regular `OrderPayment` row ("Store credit", transaction id = the consumed codes) next to the gateway payment, so payments and totals reconcile everywhere with zero template changes. The spend runs after all orders of the cart are created, inside a guarded block that restores the credit before rethrowing on any later failure.
- **`OrderHistory::changeIdOrderState()`**: credit spent on an order that lands in an error or cancelled state is restored automatically (idempotent, claim-before-refund), mirroring the stock re-injection. Refund states stay merchant-controlled on purpose.
- **`Cart::getOrderTotal()` credit branch**: floors the applied amount at the currency display precision (sub-cent balance dust no longer aborts the checkout) and only applies credit to default-currency carts, because credits carry no currency.
- `StoreCredit::getByCustomerId()` reads from master (the figure decides how much money a checkout may spend).
- BO: read-only spend history (date, order link, amount, spent/reverted) on the credit edit form.
- Second commit fixes pre-existing swapped `(shopId, customerId)` arguments in both `ParentOrderController` balance lookups.

## Testing

Functionally tested against a live database: consumption order, read-back, shortfall revert, restore on cancellation incl. idempotence, external compensation, and the conditional-debit race guard (second identical debit affects zero rows). Schema is definition-driven; both models added to `WebserviceMetadataTest::NOT_EXPOSED`.

## Known limitations (documented, out of scope)

- Concurrent duplicate `validateOrder()` for one cart (pre-existing TOCTOU on `orderExists()`) can create two orders and legitimately debit twice.
- All-virtual carts bypass the credit branch (`BOTH` is rewritten to `BOTH_WITHOUT_SHIPPING` before it).
- Automatic restore on refunds/credit slips is a suggested follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)