### PR TITLE
Allow store credit redemption without an account (optional)

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1118,10 +1118,18 @@ class CartCore extends ObjectModel
         // Store credits carry no currency, so they are only applied to carts
         // in the shop default currency; a JPY cart would otherwise drain a
         // EUR-granted balance one-to-one.
-        if ($orderTotal > 0 && $this->use_store_credit && (int)$this->id_customer
+        if ($orderTotal > 0 && $this->use_store_credit
             && (int)$this->id_currency === (int)Configuration::get('PS_CURRENCY_DEFAULT')) {
             if ($type == static::BOTH || $type == static::ONLY_STORE_CREDIT) {
-                $creditAvailable = StoreCredit::getByCustomerId((int)$this->id_shop, (int)$this->id_customer);
+                // Claimed balance of the signed-in customer, plus unclaimed
+                // credits attached to the cart before sign-in (guest
+                // redemption). The two sets cannot overlap: attached credits
+                // only count while unclaimed.
+                $creditAvailable = 0.0;
+                if ((int)$this->id_customer) {
+                    $creditAvailable = StoreCredit::getByCustomerId((int)$this->id_shop, (int)$this->id_customer);
+                }
+                $creditAvailable += StoreCredit::getAttachedAmountForCart((int)$this->id_shop, (int)$this->id);
                 // FLOOR to the display precision. The credit balance can hold
                 // sub-precision dust (6-decimal column); rounding UP would
                 // promise more than the balance covers and make the order-time
@@ -2931,6 +2939,7 @@ class CartCore extends ObjectModel
         );
 
         if (!$conn->delete('cart_cart_rule', '`id_cart` = '.(int) $this->id)
+            || !$conn->delete('cart_store_credit', '`id_cart` = '.(int) $this->id)
             || !$conn->delete('cart_product', '`id_cart` = '.(int) $this->id)
         ) {
             return false;
@@ -4144,7 +4153,7 @@ class CartCore extends ObjectModel
         }
 
         $discounts = array_values($cartRules);
-        if ($this->use_store_credit && (int)$this->id_customer) {
+        if ($this->use_store_credit) {
             $creditUsed = $this->getOrderTotal(true, static::ONLY_STORE_CREDIT);
             if ($creditUsed > 0.0) {
                 $baseTotalTaxInc -= $creditUsed;
@@ -4154,6 +4163,12 @@ class CartCore extends ObjectModel
                     'code' => ParentOrderController::STORE_CREDIT_CODE,
                     'id_customer' => $this->id_customer,
                     'value_real' => $creditUsed,
+                    // Credit is a payment, not a taxed line: tax-excluded
+                    // displays show the same figure. Both keys are read by
+                    // the theme's cart summary next to value_real.
+                    'value_tax_exc' => $creditUsed,
+                    'description' => '',
+                    'free_shipping' => 0,
                     'name' => 'Store credit',
                 ];
             }

--- a/classes/CartStoreCredit.php
+++ b/classes/CartStoreCredit.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Copyright (C) 2025-2026 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <contact@thirtybees.com>
+ * @copyright 2026 thirty bees
+ * @license   Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class CartStoreCreditCore
+ *
+ * Associates an unclaimed store credit code with a cart, so a visitor can
+ * enter the code before signing in (guest redemption, enabled with the
+ * PS_STORE_CREDIT_GUEST setting). The association only carries weight while
+ * the credit is unclaimed: the moment a credit is claimed by an account, the
+ * customer balance takes over and stale associations stop counting.
+ */
+class CartStoreCreditCore extends ObjectModel
+{
+    /**
+     * @var int $id
+     */
+    public $id;
+
+    /**
+     * @var int $id_cart
+     */
+    public $id_cart;
+
+    /**
+     * @var int $id_store_credit
+     */
+    public $id_store_credit;
+
+    /**
+     * @var string $date_add
+     */
+    public $date_add;
+
+    /**
+     * @var array Object model definition
+     */
+    public static $definition = [
+        'table'   => 'cart_store_credit',
+        'primary' => 'id_cart_store_credit',
+        'fields'  => [
+            'id_cart'         => ['type' => self::TYPE_INT,  'validate' => 'isUnsignedId', 'required' => true],
+            'id_store_credit' => ['type' => self::TYPE_INT,  'validate' => 'isUnsignedId', 'required' => true],
+            'date_add'        => ['type' => self::TYPE_DATE, 'validate' => 'isDate', 'dbNullable' => false],
+        ],
+        'keys' => [
+            'cart_store_credit' => [
+                'cart_credit' => ['type' => ObjectModel::UNIQUE_KEY, 'columns' => ['id_cart', 'id_store_credit']],
+                'id_store_credit' => ['type' => ObjectModel::KEY, 'columns' => ['id_store_credit']],
+            ],
+        ],
+    ];
+
+    /**
+     * Attaches a store credit to a cart. Idempotent: attaching the same code
+     * twice is a no-op thanks to the unique key.
+     *
+     * @param int $idCart
+     * @param int $idStoreCredit
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    public static function attach(int $idCart, int $idStoreCredit): bool
+    {
+        if ($idCart <= 0 || $idStoreCredit <= 0) {
+            return false;
+        }
+        if (static::isAttached($idCart, $idStoreCredit)) {
+            return true;
+        }
+        $association = new CartStoreCredit();
+        $association->id_cart = $idCart;
+        $association->id_store_credit = $idStoreCredit;
+        try {
+            $added = $association->add();
+        } catch (PrestaShopException $e) {
+            // Db only throws under _PS_DEBUG_SQL_; treat the exception the
+            // same as a false return below.
+            $added = false;
+        }
+        if (!$added) {
+            // A concurrent attach of the same code hits the unique key; that
+            // still means "attached", anything else is a real failure.
+            if (static::isAttached($idCart, $idStoreCredit)) {
+                return true;
+            }
+            Logger::addLog(
+                'CartStoreCredit::attach() failed for cart ' . $idCart . ', credit ' . $idStoreCredit,
+                3
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param int $idCart
+     * @param int $idStoreCredit
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    public static function isAttached(int $idCart, int $idStoreCredit): bool
+    {
+        // Master connection: attach() relies on this recheck to recognize a
+        // concurrently inserted row, which a lagging replica may not show yet.
+        return (bool) Db::getInstance()->getValue((new DbQuery())
+            ->select('id_cart_store_credit')
+            ->from('cart_store_credit')
+            ->where('id_cart = ' . $idCart)
+            ->where('id_store_credit = ' . $idStoreCredit)
+        );
+    }
+
+    /**
+     * Removes every credit association from a cart. Used when the customer
+     * removes the store credit line from the cart summary.
+     *
+     * @param int $idCart
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    public static function deleteForCart(int $idCart): bool
+    {
+        $deleted = Db::getInstance()->delete('cart_store_credit', 'id_cart = ' . $idCart);
+        if (!$deleted) {
+            Logger::addLog('CartStoreCredit::deleteForCart() failed for cart ' . $idCart, 3);
+        }
+        return $deleted;
+    }
+}

--- a/classes/StoreCredit.php
+++ b/classes/StoreCredit.php
@@ -260,11 +260,65 @@ class StoreCreditCore extends ObjectModel
     }
 
     /**
+     * Whether visitors may redeem store credit codes without signing in
+     * (shop setting, off by default). When enabled, an unclaimed code entered
+     * before sign-in is attached to the cart and spent at order validation;
+     * codes already claimed by an account stay bound to that account.
+     *
+     * @return bool
+     *
+     * @throws PrestaShopException
+     */
+    public static function guestRedeemEnabled(): bool
+    {
+        return (bool) Configuration::get('PS_STORE_CREDIT_GUEST');
+    }
+
+    /**
+     * Spendable total of the credits attached to a cart (guest redemption).
+     * Only unclaimed credits count: once a credit is claimed by an account,
+     * the owner's balance takes over and a stale cart association must not
+     * make the same money spendable twice.
+     *
+     * @param int $shopId
+     * @param int $cartId
+     *
+     * @return float
+     *
+     * @throws PrestaShopException
+     */
+    public static function getAttachedAmountForCart(int $shopId, int $cartId): float
+    {
+        // The setting is the kill switch: turning it off immediately stops
+        // attachments from counting (and, via spendForOrder, from being
+        // spent), including carts that attached a code while it was on.
+        if ($cartId <= 0 || !static::guestRedeemEnabled()) {
+            return 0.0;
+        }
+        // Master connection for the same reason as getByCustomerId(): this
+        // figure decides how much money the checkout may spend.
+        $conn = Db::getInstance();
+        $sql = (new DbQuery())
+            ->select('SUM(c.amount - c.amount_used)')
+            ->from('store_credit', 'c')
+            ->innerJoin('cart_store_credit', 'csc', 'c.id_store_credit = csc.id_store_credit AND csc.id_cart = ' . (int) $cartId)
+            ->innerJoin('store_credit_shop', 'cs', 'c.id_store_credit = cs.id_store_credit AND cs.id_shop = ' . (int) $shopId)
+            ->where('c.id_customer = 0')
+            ->where('c.date_from <= NOW()')
+            // Dates before 1900 mean "no expiry", see getByCustomerId().
+            ->where('(c.date_to < "1900-00-00" OR c.date_to >= NOW())');
+        return (float) $conn->getValue($sql);
+    }
+
+    /**
      * Debit $amount from the order's customer credit balance and record one
      * StoreCreditSpend row per credit touched. This is the durable side of
      * paying with store credit: Cart::getOrderTotal() only lowers the payable
      * total, and without this booking the balance would never decrease and
      * nothing on the order would show the credit was used.
+     *
+     * With guest redemption enabled, unclaimed credits attached to the
+     * order's cart are debited too; those stay unclaimed afterwards.
      *
      * Credits are consumed deterministically: soonest expiry first (credits
      * without an expiry last), then oldest first. Each debit is a single
@@ -295,12 +349,25 @@ class StoreCreditCore extends ObjectModel
             throw new PrestaShopException('Store credit can only be spent by a customer account.');
         }
 
+        // Besides the customer's own claimed credits, unclaimed credits
+        // attached to the order's cart are spendable too (guest redemption:
+        // the code was entered before sign-in). Such credits stay unclaimed
+        // after the spend, so the code keeps working for its holder. Gated on
+        // the same setting as the counting side, so the two never disagree.
+        $spendable = 'c.id_customer = ' . $idCustomer;
+        $idCart = (int) $order->id_cart;
+        if ($idCart > 0 && static::guestRedeemEnabled()) {
+            $spendable = '(' . $spendable . ' OR (c.id_customer = 0 AND c.id_store_credit IN (
+                SELECT csc.id_store_credit FROM `' . _DB_PREFIX_ . 'cart_store_credit` csc WHERE csc.id_cart = ' . $idCart . '
+            )))';
+        }
+
         $conn = Db::getInstance();
         $candidates = $conn->getArray((new DbQuery())
             ->select('c.id_store_credit, c.code, c.amount, c.amount_used')
             ->from('store_credit', 'c')
             ->innerJoin('store_credit_shop', 'cs', 'c.id_store_credit = cs.id_store_credit AND cs.id_shop = ' . (int) $order->id_shop)
-            ->where('c.id_customer = ' . $idCustomer)
+            ->where($spendable)
             ->where('c.date_from <= NOW()')
             // Dates before 1900 mean "no expiry", see getByCustomerId().
             ->where('(c.date_to < "1900-00-00" OR c.date_to >= NOW())')

--- a/classes/module/PaymentModule.php
+++ b/classes/module/PaymentModule.php
@@ -565,7 +565,13 @@ abstract class PaymentModuleCore extends Module
                     // with/without difference, so it mirrors exactly what the
                     // totals deducted.
                     $storeCreditApplied = 0.0;
-                    if ($this->context->cart->use_store_credit && (int) $this->context->cart->id_customer) {
+                    // No id_customer condition here: Cart::getOrderTotal()
+                    // subtracts credit without one (guest carts), so gating
+                    // the gross-up on it would price an order net of a credit
+                    // that is never debited. A truly customerless order makes
+                    // spendForOrder() throw, which is the loud failure we
+                    // want for that broken state.
+                    if ($this->context->cart->use_store_credit) {
                         $grossTaxIncl = (float) $this->context->cart->getOrderTotal(true, Cart::BOTH_WITHOUT_STORE_CREDIT, $productList, $idCarrier);
                         $storeCreditApplied = Tools::roundPrice($grossTaxIncl - $order->total_paid_tax_incl);
                         if ($storeCreditApplied > 0) {

--- a/controllers/admin/AdminOrderPreferencesController.php
+++ b/controllers/admin/AdminOrderPreferencesController.php
@@ -104,6 +104,13 @@ class AdminOrderPreferencesControllerCore extends AdminController
                         'cast'       => 'intval',
                         'type'       => 'bool',
                     ],
+                    'PS_STORE_CREDIT_GUEST'          => [
+                        'title'      => $this->l('Allow store credit codes without an account'),
+                        'hint'       => $this->l('Visitors can enter an unclaimed store credit code before signing in; it is spent when the order is placed and any remaining balance keeps working for whoever holds the code. Codes already claimed by an account stay bound to that account.'),
+                        'validation' => 'isBool',
+                        'cast'       => 'intval',
+                        'type'       => 'bool',
+                    ],
                     'PS_DISALLOW_HISTORY_REORDERING' => [
                         'title'      => $this->l('Disable Reordering Option'),
                         'hint'       => $this->l('Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).'),

--- a/controllers/front/ParentOrderController.php
+++ b/controllers/front/ParentOrderController.php
@@ -159,18 +159,31 @@ class ParentOrderControllerCore extends FrontController
                                 Tools::redirect('index.php?controller=order&addingCartRule=1');
                             }
                         } elseif (($storeCredit = StoreCredit::getByCode($code))) {
-                            if (!$customerId) {
+                            if (!$customerId && !StoreCredit::guestRedeemEnabled()) {
                                 $this->errors[] = Tools::displayError('You need to sign in before you can redeem store credit vouchers');
                             } elseif ((int)$storeCredit->id_customer && (int)$storeCredit->id_customer !== $customerId) {
                                 // Codes are bearer secrets: once a credit is bound to an
                                 // account, (re)entering its code must never move it to
-                                // another customer's account.
-                                $this->errors[] = Tools::displayError('This code has already been redeemed.');
+                                // another customer's account. Guests get one generic
+                                // refusal for every state, so anonymous visitors cannot
+                                // probe whether a code is claimed, expired or empty.
+                                $this->errors[] = $customerId
+                                    ? Tools::displayError('This code has already been redeemed.')
+                                    : Tools::displayError('This code cannot be redeemed.');
                             } elseif (!$storeCredit->isCurrentlyValid()) {
-                                $this->errors[] = Tools::displayError('This code is no longer valid.');
+                                $this->errors[] = $customerId
+                                    ? Tools::displayError('This code is no longer valid.')
+                                    : Tools::displayError('This code cannot be redeemed.');
                             } elseif ($storeCredit->getRemainingAmount() <= 0) {
-                                $this->errors[] = Tools::displayError('This code has no remaining balance.');
-                            } elseif (!$storeCredit->claimForCustomer($customerId)) {
+                                $this->errors[] = $customerId
+                                    ? Tools::displayError('This code has no remaining balance.')
+                                    : Tools::displayError('This code cannot be redeemed.');
+                            } elseif ($customerId && !$storeCredit->claimForCustomer($customerId)) {
+                                $this->errors[] = Tools::displayError('This code could not be redeemed. Please contact customer service.');
+                            } elseif (!$customerId && !CartStoreCredit::attach((int)$this->context->cart->id, (int)$storeCredit->id)) {
+                                // Guest redemption: the code is not claimed but attached
+                                // to the cart; the spend at order validation links it to
+                                // the order, and the credit stays unclaimed afterwards.
                                 $this->errors[] = Tools::displayError('This code could not be redeemed. Please contact customer service.');
                             } else {
                                 $cart = $this->context->cart;
@@ -199,6 +212,9 @@ class ParentOrderControllerCore extends FrontController
                     } elseif ($discount === static::STORE_CREDIT_CODE) {
                         $this->context->cart->use_store_credit = false;
                         $this->context->cart->save();
+                        // Also unhook any codes attached before sign-in, so
+                        // removing the store credit line removes everything.
+                        CartStoreCredit::deleteForCart((int)$this->context->cart->id);
                         Tools::redirect('index.php?controller=order-opc');
                     }
                 }

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -314,6 +314,9 @@
     <configuration id="PS_GUEST_CHECKOUT_ENABLED" name="PS_GUEST_CHECKOUT_ENABLED">
       <value>0</value>
     </configuration>
+    <configuration id="PS_STORE_CREDIT_GUEST" name="PS_STORE_CREDIT_GUEST">
+      <value>0</value>
+    </configuration>
     <configuration id="PS_DISPLAY_SUPPLIERS" name="PS_DISPLAY_SUPPLIERS">
       <value>1</value>
     </configuration>

--- a/tests/Integration/WebserviceMetadataTest.php
+++ b/tests/Integration/WebserviceMetadataTest.php
@@ -12,6 +12,7 @@ use WebserviceRequest;
 use AddressFormat;
 use Alias;
 use Attachment;
+use CartStoreCredit;
 use CMSRole;
 use CompareProduct;
 use ConfigurationKPI;
@@ -57,6 +58,7 @@ class WebserviceMetadataTest extends Unit
         AddressFormat::class,
         Alias::class,
         Attachment::class,
+        CartStoreCredit::class, // internal cart association
         CMSRole::class,
         CompareProduct::class,
         ConfigurationKPI::class,

--- a/tests/Support/override/classes/CartStoreCredit.php
+++ b/tests/Support/override/classes/CartStoreCredit.php
@@ -1,0 +1,6 @@
+<?php
+
+class CartStoreCredit extends CartStoreCreditCore
+{
+
+}

--- a/tests/golden_files/db_schema.sql
+++ b/tests/golden_files/db_schema.sql
@@ -369,6 +369,16 @@ CREATE TABLE `PREFIX_cart_rule_shop` (
   PRIMARY KEY (`id_cart_rule`,`id_shop`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE `PREFIX_cart_store_credit` (
+  `id_cart_store_credit` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `id_cart` int(11) unsigned NOT NULL,
+  `id_store_credit` int(11) unsigned NOT NULL,
+  `date_add` datetime NOT NULL,
+  PRIMARY KEY (`id_cart_store_credit`),
+  UNIQUE KEY `cart_credit` (`id_cart`,`id_store_credit`),
+  KEY `id_store_credit` (`id_store_credit`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE `PREFIX_category` (
   `id_category` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `id_parent` int(11) unsigned NOT NULL,


### PR DESCRIPTION
Follow-up to the store credit spend persistence work. New shop setting **PS_STORE_CREDIT_GUEST**, off by default: existing shops keep today's behavior byte for byte.

## Problem

A store credit code can only be entered by a signed-in customer. For gift cards that is a real hurdle: the recipient just wants to type the code and check out, as guest or account holder. The early sign-in requirement predates the spend log; now that every spend is recorded per order (which always has a customer and an e-mail address), it no longer buys the bookkeeping anything.

## Change

When the setting is enabled:

- An **unclaimed** code entered before sign-in is attached to the cart via a new `cart_store_credit` association (definition-driven model). Cart totals count attached credits next to the customer balance; the sets cannot overlap because attachments only count while the credit is unclaimed.
- At order validation `StoreCredit::spendForOrder()` spends the customer's claimed credits AND the credits attached to the order's cart, soonest expiry first, through the same conditional-debit race guard. **The credit stays unclaimed after a guest spend**: the remainder keeps working for whoever holds the code, like a paper gift card, while every debit stays traceable through `store_credit_spend`.
- Codes **claimed by an account stay bound to that account** and are refused for anyone else; signed-in redemption still claims, unchanged.
- The setting is also the **kill switch**: turning it off immediately stops attachments from counting and from being spent.
- Guests get one generic refusal for every code state, so anonymous visitors cannot probe whether a code is claimed, expired or empty. Signed-in customers keep the specific messages.
- Removing the store credit line removes the attachments; `Cart::delete()` cleans the association table; failed association writes are logged; the credit gross-up in `PaymentModule::validateOrder()` no longer requires a cart customer, so totals and spend can never disagree silently.

## Testing

Functional tests against a live database (13 checks): attach idempotence under the unique key, attached amount counts only unclaimed valid credits, kill switch, mixed customer+attached spend in expiry order, remainder spendable from a fresh cart, unattached credit not spendable, cleanup. Plus a 9-check regression run over the existing claimed-credit spend path. A three-agent review (security and money paths, conventions, platform integration) ran over the change; all confirmed findings are fixed in this commit.

## Known trade-off

Two holders of one bearer code checking out concurrently cannot double-spend (conditional balance-guarded debit), but the losing checkout aborts at validation, which for redirect gateways is after payment. This failure class already exists for one customer's claimed credit used from two devices; bearer semantics widen who can trigger it. Documented rather than solved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
