### PR TITLE
Fix bool list filter showing dash when filtering on No

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -325,8 +325,8 @@
 								{if $params.type === HelperList::COLUMN_TYPE_BOOL}
 									<select class="filter fixed-width-xs center" onchange="$('#submitFilterButton{$list_id}').focus();$('#submitFilterButton{$list_id}').click();" name="{$list_id}Filter_{if isset($params.filter_key)}{$params.filter_key}{else}{$key}{/if}">
 										<option value="">-</option>
-										<option value="1" {if $params.value == 1} selected="selected" {/if}>{l s='Yes'}</option>
-										<option value="0" {if $params.value == 0 && $params.value != ''} selected="selected" {/if}>{l s='No'}</option>
+										<option value="1" {if $params.value === true || $params.value === 1 || $params.value === '1'} selected="selected" {/if}>{l s='Yes'}</option>
+										<option value="0" {if $params.value === false || $params.value === 0 || $params.value === '0'} selected="selected" {/if}>{l s='No'}</option>
 									</select>
 								{elseif $params.type === HelperList::COLUMN_TYPE_DATE || $params.type == HelperList::COLUMN_TYPE_DATETIME}
 									<div class="date_range row">


### PR DESCRIPTION
Bool column filters are deserialized to real PHP booleans (BoolValueType::deserializeValue), so a No filter reaches list_header.tpl as false. The No option's selected check required 'value != empty string', and false loosely equals empty string in PHP, so the option was never marked selected: the list was correctly filtered on No while the dropdown displayed the unfiltered dash. Affects every COLUMN_TYPE_BOOL filter in every admin list. Fixed by comparing strictly against the boolean, int and string representations for both options; the dash still shows for null/empty (no filter). Found while testing the WMS fulfilment list Paused/Batch filters.