### PR TITLE
Fix zero shipping cost when customer address changes mid-checkout

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2843,7 +2843,21 @@ class CartCore extends ObjectModel
                 $this->id_address_delivery = $idAddressNew;
             }
             if ($toUpdate) {
+                // Re-key the stored delivery option(s) onto the new address id,
+                // otherwise a mid-checkout address change leaves them stored
+                // under the old id, where they fail validation in
+                // getDeliveryOption() and the shipping cost evaluates to 0.
+                $deliveryOption = json_decode($this->delivery_option, true);
+                if (is_array($deliveryOption) && array_key_exists($idAddress, $deliveryOption)) {
+                    $deliveryOption[$idAddressNew] = $deliveryOption[$idAddress];
+                    unset($deliveryOption[$idAddress]);
+                    $this->delivery_option = json_encode($deliveryOption);
+                }
                 $this->update();
+
+                // The delivery option list is cached per cart and country; the
+                // address change invalidates it.
+                Cache::clean('Cart::getDeliveryOptionList_' . (int) $this->id . '_*');
             }
 
             $conn = Db::getInstance();


### PR DESCRIPTION
Fixes #2140

**Problem**
When a customer adds or changes the delivery address mid-checkout (e.g. PayPal express checkout returns a different address and thirty bees duplicates it: old id 27115 -> new id 27116), the created order ends up with `total_shipping` of exactly 0.00, while the payment gateway charged the customer the correct amount including shipping.

**Root cause**
`Cart::updateAddressId()` rewrites `id_address_invoice`, `id_address_delivery`, `cart_product.id_address_delivery`, and `customization.id_address_delivery` - but never re-keys `$this->delivery_option`, the JSON map of `{ address_id: delivery_option_key }`. The stored delivery option keeps the stale address key, fails validation in `Cart::getDeliveryOption()` (which checks it against a delivery option list keyed by the current address ids), and the shipping cost silently evaluates to 0.00.

**Fix**
In `Cart::updateAddressId()`, re-key `delivery_option` from the old address id to the new one (decoded, remapped, re-encoded, persisted by the existing `$this->update()`), and flush the per-cart delivery option list cache (`Cart::getDeliveryOptionList_{id_cart}_*`), which is otherwise served stale after an address change.

Single file, `classes/Cart.php`, +14/-0. Behavior is unchanged when no delivery option is stored or its key does not match the changed address.

**Verification**
Traced on current `main` (c72125d): `updateAddressId()` never touches `delivery_option`; `getDeliveryOption()` (classes/Cart.php:1228) rejects stale-keyed stored options; `getTotalShippingCost()` (classes/Cart.php:1190) then skips the missing key and returns 0. No test suite covers `Cart::updateAddressId()` in this repo; the change is a guarded remap inside the existing update path.

Credit for the root-cause analysis goes to thirty bees forum user DRMasterChief, who reported and traced this 10 days ago: https://forum.thirtybees.com/topic/8559-paypal-shipping-bug-report-not-paypal-specific/

> Built by breken, your AI support engineer - breken.ai - this one's on us.